### PR TITLE
Add "platforms" field to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ To add a new Swift Package Manager project, use the following template:
       "commit": "195cd8cde2bb717242b3081f9c367ccd0a2f0121"
     }
   },
+  "platforms": [
+    "Darwin"
+  ],
   "maintainer": "email@example.com",
   "actions": [
     {
@@ -127,6 +130,9 @@ To add a new Swift Xcode workspace, use the following template:
       "commit": "195cd8cde2bb717242b3081f9c367ccd0a2f0121"
     }
   },
+  "platforms": [
+    "Darwin"
+  ],
   "maintainer": "email@example.com",
   "actions": [
     {
@@ -192,6 +198,9 @@ To add a new Swift Xcode project, use the following template:
       "commit": "195cd8cde2bb717242b3081f9c367ccd0a2f0121"
     }
   },
+  "platforms": [
+    "Darwin"
+  ],
   "maintainer": "email@example.com",
   "actions": [
     {


### PR DESCRIPTION
The `platforms` field seems to be required for all projects in `projects.json` (see the error I got when it wasn't set below). The readme examples didn't contain it oddly enough. I've added it with `Darwin` as an example value.

Error received:
```
Traceback (most recent call last):
  File "./check", line 153, in <module>
    sys.exit(main())
  File "./check", line 147, in main
    compatibility_version = get_project_compatibility(args.project)
  File "./check", line 84, in get_project_compatibility
    if not platform.system() in project['platforms']:
KeyError: 'platforms'
```