### PR TITLE
Add SwiftGraph Against Swift 3.1

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -755,7 +755,7 @@
     "branch": "master",
     "maintainer": "david@oaksnow.com",
     "compatibility": {
-      "3.0": {
+      "3.1": {
         "commit": "07b088eef5cb883e5544ea4d2e9a1338318f0596"
       }
     },

--- a/projects.json
+++ b/projects.json
@@ -750,38 +750,23 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/louisdh/panelkit.git",
-    "path": "panelkit",
+    "url": "https://github.com/davecom/SwiftGraph.git",
+    "path": "SwiftGraph",
     "branch": "master",
+    "maintainer": "david@oaksnow.com",
     "compatibility": {
       "3.0": {
-        "commit": "d451d956fb31f0ca5d76940c0b1db46b8c74a089"
+        "commit": "07b088eef5cb883e5544ea4d2e9a1338318f0596"
       }
     },
     "platforms": [
-      "Darwin"
+      "Darwin",
+      "Linux"
     ],
-    "maintainer": "louisdhauwe@silverfox.be",
     "actions": [
       {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "PanelKit.xcworkspace",
-        "scheme": "PanelKit",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "PanelKit.xcworkspace",
-        "scheme": "Example",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "PanelKit.xcworkspace",
-        "scheme": "PanelKitTests",
-        "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
       }
     ]
   }


### PR DESCRIPTION
### Pull Request Description

SwiftGraph is a graph data structure and related algorithms. It wasn't clear to me from the README if you're yet accepting 3.1 pull requests because it said the 3.0s were "examples." Specifically, I mean this section:

```
After adding a new project to the index, ensure it builds successfully at the pinned commits against the specified versions of Swift. In the examples, the commits are specified as being compatible with Swift 3.0, which is included in Xcode 8.0.
```

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [X] be an *Xcode* or *swift package manager* project
- [X] support building on either Linux or macOS
- [X] target Linux, macOS, or iOS/tvOS/watchOS device
- [X] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [X] have maintainers who will commit to resolve issues in a timely manner
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [X] add value not already included in the suite
- [X] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [X] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.
