### PR TITLE
Add PinkyPromise

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -834,5 +834,57 @@
         "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/willowtreeapps/PinkyPromise.git",
+    "path": "PinkyPromise",
+    "branch": "master",
+    "compatibility": {
+      "3.0": {
+        "commit": "a127ac74685daec77dd4580bd82c8ace8cc9cc29"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "maintainer": "connerk@gmail.com",
+    "actions": [
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "PinkyPromise.xcodeproj",
+        "scheme": "PinkyPromise_iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "PinkyPromise.xcodeproj",
+        "scheme": "PinkyPromise_macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestXcodeProjectScheme",
+        "project": "PinkyPromise.xcodeproj",
+        "scheme": "PinkyPromise_iOS",
+        "destination": "platform=iOS Simulator,name=iPhone 7",
+        "configuration": "Release"
+      },
+      {
+        "action": "TestXcodeProjectScheme",
+        "project": "PinkyPromise.xcodeproj",
+        "scheme": "PinkyPromise_macOS",
+        "destination": "platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

PinkyPromise is an almost-Promises library used to build composable, repeatable, failable asynchronous tasks in functional style. It has thorough tests, documentation, and a teaching playground. It's distributable by source, CocoaPods, Carthage, and the Swift Package Manager.

This library includes a lot of generics, tuples, throwing, and function parameters/properties. Uses of PinkyPromise tend to include chained generic closure expressions that strain type inference. If there is a project in the suite that covers the same territory already, it's likely to be RxSwift. Let that be your litmus test.

PinkyPromise has no dependencies besides basic Foundation, so should work on Linux. But my Vagrant-fu is shallow, and I haven't been able to verify. I've only included Darwin for now.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run