### PR TITLE
Add GRDB.swift

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -834,5 +834,29 @@
         "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/groue/GRDB.swift.git",
+    "path": "GRDB.swift",
+    "branch": "master",
+    "compatibility": {
+      "3.1": {
+        "commit": "3eb2646cad7ad787b92237f717e670e639dc8c92"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "maintainer": "gwendal.roue@gmail.com",
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

Hello, this PR adds source compatibility tests for [GRDB.swift](http://github.com/groue/GRDB.swift), a toolkit for SQLite databases, focused on application development.

### Acceptance Criteria

- [X] be an *Xcode* or *swift package manager* project: **both**
- [X] support building on either Linux or macOS: **macOS**
- [X] target Linux, macOS, or iOS/tvOS/watchOS device: **Apple devices**
- [X] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests

    GRDB requires Xcode 8.1+, and won't build with the toolchain included in Xcode 8.0 (compiler crash). This is why the checked Swift version is 3.1.

- [X] have maintainers who will commit to resolve issues in a timely manner
    
    GRDB was born in June 2015, has evolved from Swift 2.1 to Swift 3.1, and has a very low number of open issues. It enjoys a small community of involved users that help enhancing a robust and well-appreciated library.
    
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*: **both**
- [X] add value not already included in the suite
    
    GRDB is a protocol-oriented database library which uses a great deal of Swift features: availability checks, fixits, fine-grained access control, interactions with C and Foundation, and dependency on a [system package](https://github.com/groue/CSQLite). It also has an in-progress [pull request](https://github.com/groue/GRDB.swift/pull/205) which adds support for Linux (not included in this PR).
    
- [X] be licensed with a permissive license: **MIT**
- [X] pass ./check script run