### PR TITLE
Add Reswifq

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -834,5 +834,30 @@
         "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/reswifq/reswifq.git",
+    "path": "reswifq",
+    "branch": "master",
+    "compatibility": {
+      "3.0": {
+        "commit": "d451d956fb31f0ca5d76940c0b1db46b8c74a089"
+      }
+    },
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "maintainer": "valerio.mazzeo@gmail.com",
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

Added Reswifq project licensed with LGPL 3.0.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [ ] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.