### PR TITLE
ReactiveSwift and ReactiveCocoa.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -834,5 +834,95 @@
         "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/ReactiveCocoa/ReactiveSwift.git",
+    "path": "ReactiveSwift",
+    "branch": "master",
+    "compatibility": {
+      "3.0": {
+        "commit": "1556b846de627cac0b96291ec2835fbc349c5e21"
+      }
+    },
+    "platforms": [
+      "Darwin", "Linux"
+    ],
+    "maintainer": "anders@andersha.com",
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveSwift.xcworkspace",
+        "scheme": "ReactiveSwift-macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveSwift.xcworkspace",
+        "scheme": "ReactiveSwift-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveSwift.xcworkspace",
+        "scheme": "ReactiveSwift-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveSwift.xcworkspace",
+        "scheme": "ReactiveSwift-watchOS",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/ReactiveCocoa/ReactiveCocoa.git",
+    "path": "ReactiveCocoa",
+    "branch": "master",
+    "compatibility": {
+      "3.0": {
+        "commit": "fdc02f188228666d56966fd4f82fb596f14576f1"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "maintainer": "anders@andersha.com",
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveCocoa.xcworkspace",
+        "scheme": "ReactiveCocoa-macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveCocoa.xcworkspace",
+        "scheme": "ReactiveCocoa-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveCocoa.xcworkspace",
+        "scheme": "ReactiveCocoa-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveCocoa.xcworkspace",
+        "scheme": "ReactiveCocoa-watchOS",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

This adds [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift) and [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveSwift) to the compatibility suite. Tests are not listed as it seems most of the existing projects do not do so.

ReactiveSwift exploits the generics system and closures to provide a set of type-safe, performant and Swift-idiomatic reactive primitives. ReactiveCocoa builds on top of ReactiveSwift and Objective-C runtime APIs to provide reactive bindings and extensions to Cocoa frameworks.

Note that ReactiveSwift is a dependency of Kickstarter-ReactiveExtensions.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with  one of the following permissive licenses:
	* MIT
- [x] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.