### PR TITLE
Add Lark project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -834,5 +834,29 @@
         "destination": "platform=iOS Simulator,name=iPad Pro (12.9 inch)"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/Bouke/Lark.git",
+    "path": "Lark",
+    "branch": "master",
+    "maintainer": "bouke@haarsma.eu",
+    "compatibility": {
+      "3.1": {
+        "commit": "fc67970caccfd23b0da802d74dcacbe8db7f1e90"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

Replace with a description of this pull request. Instructions for adding
projects are available in the README.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project: SwiftPM
- [x] support building on either Linux or macOS: macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device: macOS
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses: MIT
- [x] pass `./check Lark`

Ensure project meets all listed requirements before submitting a pull request.

### Notes
This project also builds on 3.0.2, but I don't have Xcode 8.0 hanging around. I verified it against 3.0.2-RELEASE, but the build scripts only accept Xcode's version of Swift 3.0.2.
