### PR TITLE
Add Mapper

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -533,6 +533,65 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/lyft/mapper.git",
+    "path": "mapper",
+    "branch": "master",
+    "maintainer": "k@keith.so",
+    "compatibility": {
+      "3.0": {
+        "commit": "db431abebe6b6ec632a3829edd75be0a440e331a"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Mapper.xcodeproj",
+        "target": "Mapper",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Mapper.xcodeproj",
+        "target": "Mapper",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Mapper.xcodeproj",
+        "target": "Mapper",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Mapper.xcodeproj",
+        "target": "Mapper",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Mapper.xcodeproj",
+        "target": "Mapper",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/Hearst-DD/ObjectMapper.git",
     "path": "ObjectMapper",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Mapper is a simple Swift library to convert JSON to strongly typed objects. One
advantage to Mapper over some other libraries is you can have immutable
properties.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run