### PR TITLE
Added NetService project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -725,6 +725,31 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/Bouke/NetService.git",
+    "path": "NetService",
+    "branch": "master",
+    "maintainer": "bouke@haarsma.eu",
+    "compatibility": {
+      "3.1": {
+        "commit": "4c20bd99c56f6ba370faf1d014599f7149fb834d"
+      }
+    },
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/PerfectlySoft/Perfect.git",
     "path": "Perfect",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Added NetService project. It builds and tests against 3.1, but on Linux it doesn't against 3.1.1 [SR-4754](https://bugs.swift.org/browse/SR-4754).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against **Swift 3.1** compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./check NetService`

Ensure project meets all listed requirements before submitting a pull request.