### PR TITLE
disable "treat warnings as errors" when running xcodebuild

### DIFF
--- a/project.py
+++ b/project.py
@@ -108,7 +108,8 @@ class XcodeTarget(ProjectTarget):
                    + ['-sdk', self._sdk,
                       'CODE_SIGN_IDENTITY=',
                       'CODE_SIGNING_REQUIRED=NO',
-                      'ENABLE_BITCODE=NO'])
+                      'ENABLE_BITCODE=NO',
+                      'GCC_TREAT_WARNINGS_AS_ERRORS=0'])
         for setting, value in self._build_settings.iteritems():
             command += ['%s=%s' % (setting, value)]
 
@@ -130,7 +131,8 @@ class XcodeTarget(ProjectTarget):
                       'SWIFT_LIBRARY_PATH=%s' %
                       get_stdlib_platform_path(
                           self._build_settings['SWIFT_EXEC'],
-                          self._destination)])
+                          self._destination)]
+                   + ['GCC_TREAT_WARNINGS_AS_ERRORS=0'])
         for setting, value in self._build_settings.iteritems():
             command += ['%s=%s' % (setting, value)]
 


### PR DESCRIPTION
according to a comment from Slava Pestov in [SR-4731](https://bugs.swift.org/browse/SR-4731)

> we should make it a policy that projects in the source compat suite should not build with errors as warnings enabled.

Rather than force projects to abide by this condition, simply disable "treat warnings as errors" when invoking `xcodebuild`.

I wasn't able to fully validate this was working so please confirm before merging /cc @lplarson.