### PR TITLE
Updated AsyncNinja: latest version and more platforms

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -144,8 +144,8 @@
     "path": "AsyncNinja",
     "branch": "master",
     "compatibility": {
-      "3.0": {
-        "commit": "fa34ec954f13399e6e05bbe150bfe62ee051505a"
+      "3.1": {
+        "commit": "8f661f2eee1519054b97b0ca031d917cbc361748"
       }
     },
     "maintainer": "antonvmironov@gmail.com",
@@ -202,6 +202,20 @@
         "scheme": "AsyncNinja",
         "destination": "platform=tvOS Simulator,name=Apple TV 1080p",
         "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "AsyncNinja.xcodeproj",
+        "scheme": "AsyncNinja",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      },
+      {
+         "action": "BuildSwiftPackage",
+         "configuration": "release"
+      },
+      {
+         "action": "TestSwiftPackage"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

Update previously added AsyncNinja:
- build actions were added for watchOS and swift package manager
- revision was updated
- swift version changed from 3.0 to 3.1

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.