### PR TITLE
add KeychainAccess

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -354,6 +354,54 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/kishikawakatsumi/KeychainAccess.git",
+    "path": "KeychainAccess",
+    "branch": "master",
+    "maintainer": "kishikawakatsumi@mac.com",
+    "compatibility": {
+      "3.0": {
+        "commit": "6e3d9679fd49c7ae8869454e76edf1306983c62c"
+      }
+    },
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "KeychainAccess.xcworkspace",
+        "scheme": "KeychainAccess",
+        "destination": "platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "KeychainAccess.xcworkspace",
+        "scheme": "KeychainAccess",
+        "destination": "generic/platform=iOS",
+        "scheme": "KeychainAccess",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "KeychainAccess.xcworkspace",
+        "scheme": "KeychainAccess",
+        "destination": "generic/platform=tvOS",
+        "scheme": "KeychainAccess",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "KeychainAccess.xcworkspace",
+        "scheme": "KeychainAccess",
+        "destination": "generic/platform=watchOS",
+        "scheme": "KeychainAccess",
+        "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/kickstarter/Kickstarter-Prelude",
     "path": "Kickstarter-Prelude",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

KeychainAccess is a simple Swift wrapper for Keychain API that works on iOS, watchOS, tvOS and macOS. KeychainAccess framework being added here is licensed under MIT.



### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.
