### PR TITLE
Adding the --build-config option

### DIFF
--- a/build_incremental.py
+++ b/build_incremental.py
@@ -46,7 +46,8 @@ def main():
                 args.swift_branch,
                 args.sandbox_profile_xcodebuild,
                 args.sandbox_profile_package,
-                args.add_swift_flags
+                args.add_swift_flags,
+                args.build_config
             ),
         ),
         index

--- a/builder.py
+++ b/builder.py
@@ -47,7 +47,8 @@ def main():
                 args.sandbox_profile_xcodebuild,
                 args.sandbox_profile_package,
                 args.add_swift_flags,
-                args.skip_clean
+                args.skip_clean,
+                args.build_config
             ),
         ),
         index

--- a/runner.py
+++ b/runner.py
@@ -47,7 +47,8 @@ def main():
                 args.sandbox_profile_xcodebuild,
                 args.sandbox_profile_package,
                 args.add_swift_flags,
-                args.skip_clean
+                args.skip_clean,
+                args.build_config
             ),
         ),
         index


### PR DESCRIPTION
Adding the --build-config option which gives the ability to either build with the debug or release configuration.   Capitalization is adjusted to accommodate a Swift package or an Xcode project as an implementation detail.