### PR TITLE
Update the ReactiveSwift and ReactiveCocoa entries.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1326,6 +1326,9 @@
     "compatibility": {
       "3.0": {
         "commit": "fdc02f188228666d56966fd4f82fb596f14576f1"
+      },
+      "3.1": {
+        "commit": "afe5b34d384a86fec79766672b965de56005ba42"
       }
     },
     "platforms": [
@@ -1371,6 +1374,9 @@
     "compatibility": {
       "3.0": {
         "commit": "1556b846de627cac0b96291ec2835fbc349c5e21"
+      },
+      "3.1": {
+        "commit": "b9d5b350a446b85704396ce332a1f9e4960cfc6b"
       }
     },
     "platforms": [


### PR DESCRIPTION
### Pull Request Description
Add the latest Swift 3.1 release of ReactiveSwift and ReactiveCocoa to the suite.

Note: These releases build with only Swift 3.1 though. Not quite sure if the suite accepts only 3.1 builds that are source compatible with 3.0.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* MIT
- [x] pass ./check script run
