### PR TITLE
XFAIL mapper due to warning-as-errors

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2160,35 +2160,68 @@
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-5683",
+                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-5683",
+                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectTarget",
-        "project": "Mapper.xcodeproj",
-        "target": "Mapper",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-5683",
+                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-5683",
+                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildSwiftPackage",


### PR DESCRIPTION
<rdar://problem/33875468>
[SR-5683]: source-compat-suite failure: mapper