### PR TITLE
UnXFAIL mapper for swift-4.0-branch

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2165,8 +2165,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-5683",
-                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+                "master": "https://bugs.swift.org/browse/SR-5683"
               }
             }
           }
@@ -2182,8 +2181,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-5683",
-                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+                "master": "https://bugs.swift.org/browse/SR-5683"
               }
             }
           }
@@ -2199,8 +2197,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-5683",
-                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+                "master": "https://bugs.swift.org/browse/SR-5683"
               }
             }
           }
@@ -2216,8 +2213,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-5683",
-                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-5683"
+                "master": "https://bugs.swift.org/browse/SR-5683"
               }
             }
           }


### PR DESCRIPTION
As the 'charactes deprecated' warning does not exist there.