### PR TITLE
[run_cperf] Add debug-opt config, run multithreaded / multiprocess.

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -67,7 +67,7 @@ def main():
 
     args = parse_args()
     instances = [NEW_INSTANCE, OLD_INSTANCE]
-    configs = ['debug', 'wmo-onone', 'release']
+    configs = ['debug', 'debug-opt', 'wmo-onone', 'release']
 
     for instance in instances:
         workspace = get_workspace_for_instance(instance, args)
@@ -217,11 +217,14 @@ def get_stats_dir(instance, variant):
 
 
 def get_actual_config_and_flags(config, stats):
-    flags = ("-j 1 -num-threads 1 -stats-output-dir '%s'" % stats)
-    # Handle wmo-onone as a pseudo-config
+    flags = ("-stats-output-dir '%s'" % stats)
+    # Handle as a pseudo-configs
     if config == 'wmo-onone':
         flags += ' -wmo -Onone '
         config = 'release'
+    elif config == 'debug-opt':
+        flags += ' -O '
+        config = 'debug'
     return (config, flags)
 
 


### PR DESCRIPTION
Adds a new pseudo-config Slava wants, switches off the -j 1 -num-threads 1 forced serialization for the time being, see whether it makes the timing too noisy or perturbs counters or whatever. It's more realistic anyways (in terms of user experience) and faster feedback might be worthwhile here.