### PR TITLE
AsyncNinja updated. https://bugs.swift.org/browse/SR-5998 fixed

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -82,7 +82,7 @@
     "branch": "master",
     "compatibility": {
       "3.1": {
-        "commit": "ca1eab6e3bf5588fad50f122c3294fef2f9aa79a"
+        "commit": "91b80dd2fc959b7673b5151bba41beef8e877607"
       }
     },
     "maintainer": "antonvmironov@gmail.com",

--- a/projects.json
+++ b/projects.json
@@ -109,16 +109,7 @@
         "project": "AsyncNinja.xcodeproj",
         "scheme": "AsyncNinja",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-5998"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "TestXcodeProjectScheme",


### PR DESCRIPTION
### Pull Request Description

Fixing [SR-5998](https://bugs.swift.org/browse/SR-5998) AsyncNinja source breakage: label mismatch between closure return and contextual type

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run

Ensure project meets all listed requirements before submitting a pull request.