### PR TITLE
Revert "[run_cperf] Dial back verbosity."

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -225,7 +225,7 @@ def get_stats_dir(instance, variant):
 
 
 def get_actual_config_and_flags(config, stats):
-    flags = ("-j 1 -num-threads 1 -stats-output-dir '%s'" % stats)
+    flags = ("-v -j 1 -num-threads 1 -stats-output-dir '%s'" % stats)
     # Handle pseudo-configs
     if config == 'wmo-onone':
         flags += ' -wmo -Onone '
@@ -253,6 +253,7 @@ def execute_runner(instance, workspace, configs, args):
         runner_command = [
             './runner.py',
             '--swiftc', swiftc_path,
+            '--verbose',
             '--projects', projects,
             '--build-config', config,
             '--swift-version', '3',


### PR DESCRIPTION
Revert the verbosity-revert. Possibly this is the source of nondeterminism in reactivecocoa?