### PR TITLE
[common] Make call to chflags platform-conditional on Darwin

### DIFF
--- a/common.py
+++ b/common.py
@@ -344,7 +344,8 @@ def git_submodule_update(path, stdout=sys.stdout, stderr=sys.stderr):
 def git_clean(path, stdout=sys.stdout, stderr=sys.stderr):
     """Perform a git clean operation on a path."""
     command = ['git', '-C', path, 'clean', '-ffdx']
-    check_execute(['chflags', '-R', 'nouchg', path], stdout=stdout, stderr=stderr)
+    if platform.system() == 'Darwin':
+        check_execute(['chflags', '-R', 'nouchg', path], stdout=stdout, stderr=stderr)
     return check_execute(command, stdout=stdout, stderr=stderr)
 
 


### PR DESCRIPTION
The call to 'chflags' causes linux execution of the source compat suite to fail. This fixes it.