### PR TITLE
Add Swift 4.0 compatibility commit for SwiftLint

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2024,6 +2024,9 @@
       },
       "3.1": {
         "commit": "ab664127d5d32d9ddd655b2cc313abe528a66a42"
+      },
+      "4.0": {
+        "commit": "c34c5c164954132a87e90d2312a74826a54487ed"
       }
     },
     "maintainer": "jp@jpsim.com",


### PR DESCRIPTION
### Pull Request Description

Add Swift 4.0 compatibility commit for SwiftLint.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass ./check script run

---

I have a few other questions that I wasn't fully able to ascertain from the current documentation.

### 1. What should I do about [these xfails](https://github.com/apple/swift-source-compat-suite/blob/112421cebca0ab20cbd3a9901744bcbf3d996dd5/projects.json#L2038-L2049)?

```json
"xfail": {
  "compatibility": {
    "3.0": {
      "branch": {
        "master": "https://bugs.swift.org/browse/SR-4696",
        "swift-4.1-branch": "https://bugs.swift.org/browse/SR-4696",
        "swift-4.0-branch": "https://bugs.swift.org/browse/SR-4696",
        "swift-3.1-branch": "https://bugs.swift.org/browse/SR-4696"
      }
    }
  }
}
```

The referenced bug number ([SR-4696](https://bugs.swift.org/browse/SR-4696)) was closed as "not a regression". So should I update the `3.0` & `3.1` commits to a version of SwiftLint that was adapted to support this change? Should I remove those commits from the compatibility section?

### 2. Should I use the earliest or latest commit supporting a Swift version?

For example, SwiftLint gained Swift 4 support starting around July (https://github.com/realm/SwiftLint/pull/1692), but obviously still does with the latest releases from the last month and even current `master`. So should I specify the earliest commit with support for Swift 4.0, or the _latest_ commit?

### 3. Am I allowed to add my project to `projects-incremental.json` and `projects-cperf-smoketest.json`?

It seems useful to be able to add more projects here, but it's not referenced from the README.

---

Thanks for your help!