### PR TITLE
Configure XFAILs for Swift compiler with enabled assertions

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -145,7 +145,18 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "3.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6333",
+                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-6333",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6333"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -771,28 +782,68 @@
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-TestHelpers-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-TestHelpers-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       }
     ]
   },
@@ -966,7 +1017,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "3.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -991,7 +1052,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "3.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6334"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -1419,28 +1489,68 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       }
     ]
   },
@@ -1468,28 +1578,68 @@
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6335",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
+              }
+            }
+          }
+        }
       }
     ]
   },
@@ -2037,7 +2187,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6349"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"

--- a/run
+++ b/run
@@ -59,6 +59,9 @@ def parse_args():
     parser.add_argument("--assertions",
                         help='Build Swift with asserts',
                         action='store_true')
+    parser.add_argument("--debug",
+                        help='Build Swift in debug mode',
+                        action='store_true')
     parser.add_argument("--test",
                         help='Only run test actions',
                         action='store_true')
@@ -174,7 +177,7 @@ def build_swift_toolchain(workspace, args):
     if platform.system() == 'Darwin':
         build_command = [
             os.path.join(workspace, 'swift/utils/build-script'),
-            '--debug' if args.assertions else '--release',
+            '--debug' if args.debug else '--release',
             '--assertions' if args.assertions else '--no-assertions',
             '--build-ninja',
             '--llbuild',
@@ -209,7 +212,7 @@ def build_swift_toolchain(workspace, args):
     elif platform.system() == 'Linux':
         build_command = [
             os.path.join(workspace, 'swift/utils/build-script'),
-            '--debug' if args.assertions else '--release',
+            '--debug' if args.debug else '--release',
             '--assertions' if args.assertions else '--no-assertions',
             '--build-ninja',
             '--llbuild',


### PR DESCRIPTION
This PR adds the option to control debug and assertion options independently, and configures XFAILs for a Swift compiler with assertions enabled.