### PR TITLE
Revert "XFAIL Plank and R"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1199,16 +1199,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6488"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"
@@ -1393,16 +1384,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6488"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#106

The swiftpm patch that caused the issue was reverted here: https://github.com/apple/swift-package-manager/pull/1402