### PR TITLE
Revert "XFAIL ReactiveCocoa SR-6485"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1488,7 +1488,6 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6485",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
               }
             }
@@ -1505,7 +1504,6 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6485",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
               }
             }
@@ -1522,7 +1520,6 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6485",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
               }
             }
@@ -1539,7 +1536,6 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6485",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6335"
               }
             }


### PR DESCRIPTION
Seems to be fixed.

Reverts apple/swift-source-compat-suite#105