### PR TITLE
Resolve SRP XFAIL

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1781,8 +1781,8 @@
     "branch": "master",
     "maintainer": "bouke@haarsma.eu",
     "compatibility": {
-      "3.1": {
-        "commit": "ea8a65f1b5185444364637da490356aff0daadae"
+      "4.0": {
+        "commit": "fcff1d09602d660c15b5050ea8f0359cd22563ff"
       }
     },
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -1791,7 +1791,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6537",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6537"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -1791,18 +1791,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-4968",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-4968",
-                "swift-4.0-branch": "https://bugs.swift.org/browse/SR-4968"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
Resolve SRP XFAIL by advancing project hash to a version containing a fix for SR-4968.