### PR TITLE
Resolve Sourcery XFAIL

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1838,8 +1838,8 @@
     "branch": "master",
     "maintainer": "krzysztof.zablocki@pixle.pl",
     "compatibility": {
-      "3.1": {
-        "commit": "92a180906cd5863bc6a1dea881abcfc2d9389a1f"
+      "4.0": {
+        "commit": "c96f06602d53e0eeca1fe5273f21080af63c7f31"
       }
     },
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -1848,18 +1848,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "rdar://problem/32185310",
-                "swift-4.1-branch": "rdar://problem/32185310",
-                "swift-4.0-branch": "rdar://problem/32185310"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -1848,7 +1848,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6556",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6556"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
Resolve Sourcery XFAIL by advancing project hash to a working version.