### PR TITLE
Remove SwiftLint's 3.0 commit

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2053,10 +2053,6 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "d8f5a316f29077cd22f7d129e8bfaf4f4238d6f1"
-      },
-      {
         "version": "3.1",
         "commit": "c34c5c164954132a87e90d2312a74826a54487ed"
       },
@@ -2073,17 +2069,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6617",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6617"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
SwiftLint's first commit to include SWXMLHash's change to avoid conflicting with `Sequence.Element` (https://github.com/drmohundro/SWXMLHash/commit/ed5f34cc2cc87c4bcfb7ae30a25a14aa44a16c59) was https://github.com/realm/SwiftLint/commit/7acacf6bdb29414fb2cfa56a7f5bd8219fca0637, which came after SwiftLint dropped support for Swift 3.0.

So there exists no Swift 3.0 compatible commit that also supports Swift 4's `-swift-version=3` compatibility mode.

This resolves [SR-6617](https://bugs.swift.org/browse/SR-6617).