### PR TITLE
XFAIL GRDB and ObjectMapper

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -485,18 +485,16 @@
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",
-    "xfail": {
-      "compatibility": [
-        {
-          "version": "4.0",
-          "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
-        },
-        {
-          "version": "3.1",
-          "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
-        }
-      ]
-    },
+    "compatibility": [
+      {
+        "version": "4.0",
+        "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
+      },
+      {
+        "version": "3.1",
+        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
+      }
+    ],
     "platforms": [
       "Darwin"
     ],
@@ -504,7 +502,21 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6907"
+              }
+            },
+            "3.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6907"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -1013,6 +1013,16 @@
         "scheme": "ObjectMapper-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release"
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6690"
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
+              }
+            },
+	  }
+	}
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1020,6 +1030,16 @@
         "scheme": "ObjectMapper-Mac",
         "destination": "generic/platform=macOS",
         "configuration": "Release"
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6690"
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
+              }
+            },
+	  }
+	}
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1027,6 +1047,16 @@
         "scheme": "ObjectMapper-tvOS",
         "destination": "generic/platform=tvOS",
         "configuration": "Release"
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6690"
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
+              }
+            },
+	  }
+	}
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1034,6 +1064,16 @@
         "scheme": "ObjectMapper-watchOS",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6690"
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
+              }
+            },
+	  }
+	}
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -485,16 +485,18 @@
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",
-    "compatibility": [
-      {
-        "version": "4.0",
-        "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
-      },
-      {
-        "version": "3.1",
-        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
-      }
-    ],
+    "xfail": {
+      "compatibility": [
+        {
+          "version": "4.0",
+          "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
+        },
+        {
+          "version": "3.1",
+          "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
+        }
+      ]
+    },
     "platforms": [
       "Darwin"
     ],

--- a/projects.json
+++ b/projects.json
@@ -1012,15 +1012,15 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
         "xfail": {
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
               }
-            },
+            }
 	  }
 	}
       },
@@ -1029,15 +1029,15 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-Mac",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
         "xfail": {
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
               }
-            },
+            }
 	  }
 	}
       },
@@ -1046,15 +1046,15 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
         "xfail": {
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
               }
-            },
+            }
 	  }
 	}
       },
@@ -1063,15 +1063,15 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
         "xfail": {
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6690"
               }
-            },
+            }
 	  }
 	}
       }


### PR DESCRIPTION
**XFAIL GRDB**
apple/swift#13342 uses conditional conformance to make Range a Collection when its Bound is Strideable. For compatibility, CountableRange is still available as a type alias.

There is one source compatibility issue with this: currently if you extend a CountableRange with an identical method/property as Range, you will get a compilation error of a duplicate. This shouldn't really happen – specifying CountableRange should be similar to Range where Bound: Strideable but generic type aliases need an enhancement to make this work.

GRDB is the one project that does this (Foundation also did similar things but has been changed to use RangeExpression instead, avoiding the issue). XFAILing this in the compatibility test suite until the type alias change has been made.

**XFAIL ObjectMapper** now that IUOs are removed from the type system and their use of overloading functions by different kinds of optionals in the case of `inout` parameters is something we can no longer represent.