### PR TITLE
[XFail] Kitura due to product dependencies not found (KituraNet, KituraTemplateEngine)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -844,7 +844,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6748"
+              }
+            }
+          }
+        }
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -849,7 +849,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6748"
+                "master": "https://bugs.swift.org/browse/SR-6748",
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6748"
               }
             }
           }


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-6748

Jenkins URL: https://ci.swift.org/job/swift-master-source-compat-suite/1067

```
'Kitura' /Users/buildnode/jenkins/workspace-private/swift-master-source-compat-suite/project_cache/Kitura: error: product dependency 'KituraNet' not found
'Kitura' /Users/buildnode/jenkins/workspace-private/swift-master-source-compat-suite/project_cache/Kitura: error: product dependency 'KituraTemplateEngine' not found
```
 