### PR TITLE
XFAIL GRDB until extension for constrainted typealiases is possible

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -485,18 +485,16 @@
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",
-    "xfail": {
-      "compatibility": [
-        {
-          "version": "4.0",
-          "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
-        },
-        {
-          "version": "3.1",
-          "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
-        }
-      ]
-    },
+    "compatibility": [
+      {
+        "version": "4.0",
+        "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
+      },
+      {
+        "version": "3.1",
+        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
+      }
+    ],
     "platforms": [
       "Darwin"
     ],
@@ -504,7 +502,21 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6907"
+              }
+            },
+            "3.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-6907"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -485,16 +485,18 @@
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",
-    "compatibility": [
-      {
-        "version": "4.0",
-        "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
-      },
-      {
-        "version": "3.1",
-        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
-      }
-    ],
+    "xfail": {
+      "compatibility": [
+        {
+          "version": "4.0",
+          "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
+        },
+        {
+          "version": "3.1",
+          "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
+        }
+      ]
+    },
     "platforms": [
       "Darwin"
     ],


### PR DESCRIPTION
apple/swift#13342 uses conditional conformance to make `Range` a `Collection` when its `Bound` is `Strideable`. For compatibility, `CountableRange` is still available as a type alias.

There is one source compatibility issue with this: currently if you extend a `CountableRange` with an identical method/property as `Range`, you will get a compilation error of a duplicate. This shouldn't really happen – specifying `CountableRange` should be similar to `Range where Bound: Strideable` but generic type aliases need an enhancement to make this work.

GRDB is the one project that does this (Foundation also did similar things but has been changed to use `RangeExpression` instead, avoiding the issue). XFAILing this in the compatibility test suite until the type alias change has been made.
