### PR TITLE
Update the ReactiveSwift and ReactiveCocoa entries.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1467,7 +1467,15 @@
       },
       {
         "version": "3.1",
-        "commit": "afe5b34d384a86fec79766672b965de56005ba42"
+        "commit": "339e7bdbc44f3c0e68ebc7fbbe7a59a259686703"
+      },
+      {
+        "version": "3.2",
+        "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
+      },
+      { 
+        "version": "4.0",
+        "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
       }
     ],
     "platforms": [
@@ -1562,6 +1570,14 @@
       {
         "version": "3.1",
         "commit": "b9d5b350a446b85704396ce332a1f9e4960cfc6b"
+      },
+      {
+        "version": "3.2",
+        "commit": "46fb4d4a8285286e54929add1d12f384675895c6"
+      },
+      {
+        "version": "4.0",
+        "commit": "46fb4d4a8285286e54929add1d12f384675895c6"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

Update the ReactiveSwift and ReactiveCocoa entries. 

1. Swift 3.2 and Swift 4.0 hashes for ReactiveSwift (release 3.1.0) and ReactiveCocoa (release 7.1.0).
2. Updated Swift 3.1 hash for ReactiveCocoa (release 6.0.2).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.