### PR TITLE
Add Swift 4.0 hash for antitypical/Result and update maintainer, platforms

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1524,7 +1524,7 @@
         "version": "3.2",
         "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
       },
-      { 
+      {
         "version": "4.0",
         "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
       }
@@ -1768,7 +1768,7 @@
         "commit": "1a2a979e6399dfb3574c935d6ccee36bc0214405"
       }
     ],
-    "maintainer": "rob.rix@github.com",
+    "maintainer": "matt@diephouse.com",
     "platforms": [
       "Darwin"
     ],

--- a/projects.json
+++ b/projects.json
@@ -1774,7 +1774,8 @@
     ],
     "maintainer": "matt@diephouse.com",
     "platforms": [
-      "Darwin"
+      "Darwin",
+      "Linux"
     ],
     "actions": [
       {

--- a/projects.json
+++ b/projects.json
@@ -1766,6 +1766,10 @@
       {
         "version": "3.1",
         "commit": "1a2a979e6399dfb3574c935d6ccee36bc0214405"
+      },
+      {
+        "version": "4.0",
+        "commit": "7477584259bfce2560a19e06ad9f71db441fff11"
       }
     ],
     "maintainer": "matt@diephouse.com",


### PR DESCRIPTION
- Add a Swift 4.0 hash for Result
- Set me as the maintainer since Rob is no longer involved in the project (You can see that I released [3.0](https://github.com/antitypical/Result/releases/tag/3.0.0) if you care)
- Add Linux as a supported platform because it is