### PR TITLE
Adds RxSwift 4.0 compatibility.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1877,6 +1877,10 @@
       {
         "version": "3.1",
         "commit": "102424379fb8d6c69b33b95c67504679042f44cc"
+      },
+      {
+        "version": "4.0.3",
+        "commit": "3e848781c7756accced855a6317a4c2ff5e8588b"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -1906,7 +1906,16 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.0.3": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7098"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -1906,16 +1906,7 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "4.0.3": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7098"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -1934,7 +1934,16 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.0.3": {
+              "branch": { 
+                "master": "https://bugs.swift.org/browse/SR-7098"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
### Adds RxSwift 4.0 compatibility.

I've ran `./project_precommit_check RxSwift --earliest-compatible-swift-version 4.0.3` and here are the results.

```
** CHECK **
--- Validating RxSwift Swift version 4.0.3 compatibility ---
--- Project configured to be compatible with Swift 4.0.3 ---
--- Checking RxSwift platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ /Users/kzaher/swift-source-compat-suite/runner.py --swift-branch swift-4.0-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/kzaher/swift-source-compat-suite/projects.json --include-repos 'path == "RxSwift"' --include-versions 'version == "4.0.3"' --include-actions 'action.startswith("Build")'
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-macOS, platform=macOS
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-iOS, generic/platform=iOS
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-tvOS, generic/platform=tvOS
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-watchOS, generic/platform=watchOS
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-macOS, platform=macOS
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-iOS, generic/platform=iOS
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-tvOS, generic/platform=tvOS
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-watchOS, generic/platform=watchOS
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-macOS, platform=macOS
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-iOS, generic/platform=iOS
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-tvOS, generic/platform=tvOS
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-watchOS, generic/platform=watchOS
PASS: RxSwift, 4.0.3, 3e8487, RxTests-macOS, platform=macOS
PASS: RxSwift, 4.0.3, 3e8487, RxTests-iOS, generic/platform=iOS
PASS: RxSwift, 4.0.3, 3e8487, RxTests-tvOS, generic/platform=tvOS
========================================
Action Summary:
     Passed: 15
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 15
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- RxSwift checked successfully against Swift 4.0.3 ---
```

Support for 3.0 project was already added, this is just adding 4.0 support.
