### PR TITLE
Update PromiseKit for Swift 3.1, 3.2 & 4.0

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1422,10 +1422,23 @@
       {
         "version": "3.0",
         "commit": "63ccb34a3d2834b7b08ce2014536344966399668"
+      },
+      {
+        "version": "3.1",
+        "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
+      },
+      {
+        "version": "3.2",
+        "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
+      },
+      {
+        "version": "4.0.3",
+        "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
       }
     ],
     "platforms": [
-      "Darwin"
+      "Darwin",
+      "Linux"
     ],
     "actions": [
       {


### PR DESCRIPTION
I added the same SHA for swift 3.1 and 3.2 since PromiseKit builds against 3.1, 3.2, 3.3, 4.0 and 4.1.

I added Linux as a platform, however we only support it for 4.0 and 4.1, not 3.x. It doesn't seem possible to qualify that so advise if I should alter the `json`. Thanks

```
$  ./project_precommit_check PromiseKit --earliest-compatible-swift-version 4.0.3
** CHECK **
--- Validating PromiseKit Swift version 4.0.3 compatibility ---
--- Project configured to be compatible with Swift 4.0.3 ---
--- Checking PromiseKit platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ /Users/mxcl/tmp/swift-source-compat-suite/runner.py --swift-branch swift-4.0-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/mxcl/tmp/swift-source-compat-suite/projects.json --include-repos 'path == "PromiseKit"' --include-versions 'version == "4.0.3"' --include-actions 'action.startswith("Build")'
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=macOS
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=iOS
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=watchOS
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=tvOS
========================================
Action Summary:
     Passed: 4
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 4
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- PromiseKit checked successfully against Swift 4.0.3 ---
```