### PR TITLE
Update NetService for Swift 4.0

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1093,6 +1093,10 @@
       {
         "version": "3.1",
         "commit": "4c20bd99c56f6ba370faf1d014599f7149fb834d"
+      },
+      {
+        "version": "4.0",
+        "commit": "51256c161c32570267174469ac3826b7bb3da113"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

Updated NetService library to Swift 4.0 per Luke's request.

### Acceptance Criteria

- [ ] pass `./project_precommit_check` script run -- I actually haven't tested using the script, however the build succeeds just fine with Swift 4.0 on Ubuntu 16.04.
