### PR TITLE
added 4.0 support for CoreStore

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -351,7 +351,11 @@
     "compatibility": [
       {
         "version": "3.2",
-        "commit": "305e2b61a000753b6f1aff7f3f6485a88b3ff4e7"
+        "commit": "e314db8f56b83f2cc761a70cdfc3b823b9815c03"
+      },
+      {
+        "version": "4.0",
+        "commit": "83e6082c5646c5eb4d3130ce575ab858df168c59"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description
Updated Swift 3.2 hash and added Swift 4.0 hash to existing CoreStore entry.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
