### PR TITLE
Disable an SCK project: Pods.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1891,14 +1891,32 @@
         "project": "Pods/Pods.xcodeproj",
         "target": "Pods-RxDataSources",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+            "compatibility": {
+              "3.0": {
+                "branch": {
+                  "master": "https://bugs.swift.org/browse/SR-7181"
+                }
+              }
+            }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "Pods/Pods.xcodeproj",
         "target": "Pods-Example",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+            "compatibility": {
+              "3.0": {
+                "branch": {
+                  "master": "https://bugs.swift.org/browse/SR-7181"
+                }
+              }
+            }
+        }
       }
     ]
   },


### PR DESCRIPTION
This should be reenabled again as soon as this compiler bug is fixed:
[SR-7181] Swift CI: Swift Source Compatibility Suite (master)

FAIL_RxDataSources-Pods-Pods.xcodeproj_3.0_BuildXcodeProjectTarget_Pods-Example_generic-platform-iOS.log
FAIL_RxDataSources-Pods-Pods.xcodeproj_3.0_BuildXcodeProjectTarget_Pods-RxDataSources_generic-platform-iOS.log

error: fatal error encountered during compilation; please file a bug report with your project and the crash log
<unknown>:0: note: symbol '_$S7RxSwift21AnyRecursiveSchedulerCMn' can not be undefined in a subtraction expression