### PR TITLE
Revert "Disable an SCK project: Pods."

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1891,32 +1891,14 @@
         "project": "Pods/Pods.xcodeproj",
         "target": "Pods-RxDataSources",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-            "compatibility": {
-              "3.0": {
-                "branch": {
-                  "master": "https://bugs.swift.org/browse/SR-7181"
-                }
-              }
-            }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "Pods/Pods.xcodeproj",
         "target": "Pods-Example",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-            "compatibility": {
-              "3.0": {
-                "branch": {
-                  "master": "https://bugs.swift.org/browse/SR-7181"
-                }
-              }
-            }
-        }
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#157

This bug is now fixed:
https://bugs.swift.org/browse/SR-7181