### PR TITLE
Add Swift 4 commit for R.swift

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1507,6 +1507,10 @@
       {
         "version": "3.0",
         "commit": "ac56b87a94a4ea8b795af45012d0f89d4981919e"
+      },
+      {
+        "version": "4.0",
+        "commit": "c5273e456ef02230689f6db2172abb29901115f0"
       }
     ],
     "platforms": [


### PR DESCRIPTION
I've added a Swift 4 compatible commit for R.swift

Results of `./project_precommit_check R.swift --earliest-compatible-swift-version 4.0`:

```
** CHECK **
--- Validating R.swift Swift version 4.0 compatibility ---
--- Project configured to be compatible with Swift 4.0 ---
--- Checking R.swift platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ '/Applications/Xcode 9.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc' --version
--- Version check succeeded ---
--- Executing build actions ---
$ /Users/tom/Projects/swift-source-compat-suite/runner.py --swift-branch swift-4.0-branch --swiftc '/Applications/Xcode 9.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc' --projects /Users/tom/Projects/swift-source-compat-suite/projects.json --include-repos 'path == "R.swift"' --include-versions 'version == "4.0"' --include-actions 'action.startswith("Build")'
PASS: R.swift, 4.0, c5273e, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- R.swift checked successfully against Swift 4.0 ---
```