### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ To be accepted into the Swift source compatibility test suite, a project must:
 - [ ] target Linux, macOS, or iOS/tvOS/watchOS device
 - [ ] be contained in a publicly accessible git repository
 - [ ] maintain a project branch that builds against Swift 3.0 compatibility mode
-      and passes any unit tests
+      or Swift 4.0 and passes any unit tests
 - [ ] have maintainers who will commit to resolve issues in a timely manner
 - [ ] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
 - [ ] add value not already included in the suite


### PR DESCRIPTION
At this point, requiring a 3.0 hash may not make sense for new projects. Updates project PR template to reflect this.