### PR TITLE
Xfail on 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2036,7 +2036,8 @@
           "compatibility": {
             "4.0.3": {
               "branch": { 
-                "master": "https://bugs.swift.org/browse/SR-7098"
+                "master": "https://bugs.swift.org/browse/SR-7098",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7098"
               }
             }
           }

--- a/projects.json
+++ b/projects.json
@@ -2807,7 +2807,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7233"
+                "master": "https://bugs.swift.org/browse/SR-7233",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7233"
               }
             }
           }

--- a/projects.json
+++ b/projects.json
@@ -1186,7 +1186,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
               }
             }
           }
@@ -1202,7 +1203,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
               }
             }
           }
@@ -1218,7 +1220,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
               }
             }
           }
@@ -1234,7 +1237,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690"
+                "master": "https://bugs.swift.org/browse/SR-6690",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
               }
             }
           }


### PR DESCRIPTION
### Pull Request Description

Cleaning up some failures from the 4.2 source compatibility suite testing: https://ci.swift.org/job/swift-4.2-source-compat-suite/

There are a few projects which are failing when tested against swift-4.2-branch. They're also failing on master, but have already been XFAILed there. This adds XFAILs to the projects that are failing for the same reason against both swift-4.2-branch and master.
