### PR TITLE
XFAIL Sourcery 4.0 hash on master, swift-4.2-branch

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2153,7 +2153,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6556"
+                "master": "https://bugs.swift.org/browse/SR-7273",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7273"
               }
             }
           }


### PR DESCRIPTION
A recent Swift bug fix has disallowed code that was previously allowed, causing some source breakage. (See the following bug for more information: [SR-7273](https://bugs.swift.org/browse/SR-7273))

This PR adds an XFAIL to the 4.0 configuration of Sourcery (on master and swift-4.2-branch), until an updated hash is submitted.

Note: The XFAIL from [SR-6556](https://bugs.swift.org/browse/SR-6556) is no longer valid, and is also removed as part of this PR.