### PR TITLE
Add xfail for ReSwift 3.0 configurations

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1610,7 +1610,7 @@
             "3.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7287",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287"
               }
             }
           }
@@ -1627,7 +1627,7 @@
             "3.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7287",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287"
               }
             }
           }
@@ -1644,7 +1644,7 @@
             "3.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7287",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287"
               }
             }
           }
@@ -1661,7 +1661,7 @@
             "3.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7287",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287"
               }
             }
           }

--- a/projects.json
+++ b/projects.json
@@ -1604,28 +1604,68 @@
         "project": "ReSwift.xcodeproj",
         "scheme": "ReSwift-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReSwift.xcodeproj",
         "scheme": "ReSwift-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReSwift.xcodeproj",
         "scheme": "ReSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReSwift.xcodeproj",
         "scheme": "ReSwift-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7287",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7287",
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

Project ReSwift is failing when tested against both master and swift-4.2-branch. This PR adds an xfail to ReSwift's four 3.0 configurations.

master: [Build #1520](https://ci.swift.org/job/swift-master-source-compat-suite/1520/artifact/swift-source-compat-suite/)
swift-4.2-branch: [Build #92](https://ci.swift.org/job/swift-4.2-source-compat-suite/92/artifact/swift-source-compat-suite/)

[SR-7287](https://bugs.swift.org/browse/SR-7287) has been filed to track the source breakage.