### PR TITLE
Add xfail to ReactiveCocoa 3.0, 3.2, 4.0

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1684,12 +1684,30 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
             "3.1": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-6658",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
                 "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
                 "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
+            "3.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
               }
             }
           }
@@ -1703,12 +1721,30 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
             "3.1": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-6658",
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
                 "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
                 "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
+            "3.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-7299",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658"
               }
             }
           }


### PR DESCRIPTION
### Pull Request Description

A few ReactiveCocoa configurations are failing due to [SR-7299](https://bugs.swift.org/browse/SR-7299).

This adds an xfail to the 3.0, 3.2, and 4.0 configurations. (Note: 3.1 has an existing xfail which may or may not still be valid.)