### PR TITLE
Update the compatibility suite entry of ReactiveCocoa.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1661,46 +1661,14 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            },
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            },
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -1636,20 +1636,12 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "fdc02f188228666d56966fd4f82fb596f14576f1"
-      },
-      {
-        "version": "3.1",
-        "commit": "339e7bdbc44f3c0e68ebc7fbbe7a59a259686703"
-      },
-      {
         "version": "3.2",
-        "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
+        "commit": "72dd2096c04e66bb10a5dd0c230c7a7ceef467e9"
       },
       {
         "version": "4.0",
-        "commit": "e5532fc81474ced9908965c5e4d5a91135fb2e2d"
+        "commit": "72dd2096c04e66bb10a5dd0c230c7a7ceef467e9"
       }
     ],
     "platforms": [
@@ -1662,19 +1654,7 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1684,20 +1664,6 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            },
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
-              }
-            },
             "3.2": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7299",
@@ -1721,20 +1687,6 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7299",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7299"
-              }
-            },
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
-              }
-            },
             "3.2": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7299",
@@ -1755,19 +1707,7 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6658",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6658"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

1. Remove the entries for Swift 3.0 and 3.1 and their associated xfail, since the code concerned by [SR-6658](https://bugs.swift.org/browse/SR-6658) has been resolved in a later version which however does not support Swift 3.0 and Swift 3.1 due to its dependency.

2. Update the hashes for the Swift 3.2 and Swift 4.0, which resolves [SR-7299](https://bugs.swift.org/browse/SR-7299).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      or Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.