### PR TITLE
Add xfail to 3.2 and 4.0 configs of ReactiveCocoa

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1654,28 +1654,84 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.2": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.2": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.2": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.2": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            },
+            "4.0": {
+              "branch": {
+                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

ReactiveCocoa (3.2 and possibly 4.0) is failing in the 4.1 source compat suite.

Ultimately, the problem is the same as we've seen with some other source compat projects (like [SR-7273](https://bugs.swift.org/browse/SR-7273)) where IUOs are being used in a way that is disallowed by an update to Swift.

This issue is being tracked by [SR-7356](https://bugs.swift.org/browse/SR-7346).