### PR TITLE
Remove xfail from ReactiveCocoa 4.0 config

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1661,11 +1661,6 @@
               "branch": {
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
               }
-            },
-            "4.0": {
-              "branch": {
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
-              }
             }
           }
         }
@@ -1679,11 +1674,6 @@
         "xfail": {
           "compatibility": {
             "3.2": {
-              "branch": {
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
-              }
-            },
-            "4.0": {
               "branch": {
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
               }
@@ -1703,11 +1693,6 @@
               "branch": {
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
               }
-            },
-            "4.0": {
-              "branch": {
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
-              }
             }
           }
         }
@@ -1721,11 +1706,6 @@
         "xfail": {
           "compatibility": {
             "3.2": {
-              "branch": {
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
-              }
-            },
-            "4.0": {
               "branch": {
                 "swift-4.1-branch": "https://bugs.swift.org/browse/SR-7346"
               }


### PR DESCRIPTION
### Pull Request Description

Seeing UPASS on the most recent test against swift-4.1-branch. Removes xfail from ReactiveCocoa 4.0 configurations.