### PR TITLE
Partial revert "un-XFAIL RxSwift."

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2002,7 +2002,16 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.0.3": {
+              "branch": {
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7098"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
This reverts part of commit b629cb80478a97cbf859f17adf8a61b7b75ed673.

Until we're ready to merge this into the branch, it needs to stay
XFAILed there.
