### PR TITLE
Xcode projects should know required SDK version

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -69,13 +69,12 @@ class ProjectTarget(object):
 class XcodeTarget(ProjectTarget):
     """An Xcode workspace scheme."""
 
-    def __init__(self, swiftc, project, target, destination, sdk,
+    def __init__(self, swiftc, project, target, destination,
                  added_xcodebuild_flags, is_workspace, has_scheme):
         self._swiftc = swiftc
         self._project = project
         self._target = target
         self._destination = destination
-        self._sdk = sdk
         self._added_xcodebuild_flags = added_xcodebuild_flags
         self._is_workspace = is_workspace
         self._has_scheme = has_scheme
@@ -111,8 +110,7 @@ class XcodeTarget(ProjectTarget):
                       target_param, self._target,
                       '-destination', self._destination]
                    + dir_override
-                   + ['-sdk', self._sdk,
-                      'CODE_SIGN_IDENTITY=',
+                   + ['CODE_SIGN_IDENTITY=',
                       'CODE_SIGNING_REQUIRED=NO',
                       'ENABLE_BITCODE=NO',
                       'INDEX_ENABLE_DATA_STORE=NO',
@@ -133,7 +131,6 @@ class XcodeTarget(ProjectTarget):
                    + [project_param, self._project,
                       target_param, self._target,
                       '-destination', self._destination,
-                      '-sdk', self._sdk,
                       # TODO: stdlib search code
                       'SWIFT_LIBRARY_PATH=%s' %
                       get_stdlib_platform_path(
@@ -163,28 +160,6 @@ def get_stdlib_platform_path(swiftc, destination):
     stdlib_path = os.path.join(os.path.dirname(os.path.dirname(swiftc)),
                                'lib/swift/' + stdlib_dir)
     return stdlib_path
-
-
-def get_sdk_platform_path(destination, stdout=sys.stdout, stderr=sys.stderr):
-    """Return the corresponding sdk path for a destination."""
-    platform_sdk_path = {
-        'Xcode': 'macosx',
-        'macOS': 'macosx',
-        'iOS': 'iphoneos',
-        'tvOS': 'appletvos',
-        'watchOS': 'watchos',
-    }
-    sdk_dir = None
-    for platform_key in platform_sdk_path:
-        if platform_key in destination:
-            sdk_dir = common.check_execute_output([
-                '/usr/bin/xcrun',
-                '-show-sdk-path',
-                '-sdk', platform_sdk_path[platform_key]
-            ], stdout=stdout, stderr=stderr).strip()
-            break
-    assert sdk_dir, 'Unable to find SDK'
-    return sdk_dir
 
 
 def clean_swift_package(path, swiftc, sandbox_profile,
@@ -349,8 +324,6 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
                         project_path,
                         action[match.group(3).lower()],
                         action['destination'],
-                        get_sdk_platform_path(action['destination'],
-                                              stdout=stdout, stderr=stderr),
                         initial_xcodebuild_flags + added_xcodebuild_flags,
                         is_workspace,
                         has_scheme)


### PR DESCRIPTION
### Pull Request Description

Xcode project files should already have information about
required SDK and it's unnecessary to try and guess it based
on the given destination.
