### PR TITLE
Revert "Partial revert "un-XFAIL RxSwift.""

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2002,16 +2002,7 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "4.0.3": {
-              "branch": {
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7098"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
This reverts commit f50dd084aef56d02b970f33e25493da2e9e22731.

UPASS: https://bugs.swift.org/browse/SR-7098, RxSwift, 4.0.3, 3e8487, RxCocoa-tvOS, generic/platform=tvOS