### PR TITLE
Set CODE_SIGN_IDENTIFY to "-" to match Xcode

### DIFF
--- a/project.py
+++ b/project.py
@@ -110,7 +110,7 @@ class XcodeTarget(ProjectTarget):
                       '-destination', self._destination]
                    + dir_override
                    + ['-sdk', self._sdk,
-                      'CODE_SIGN_IDENTITY=',
+                      'CODE_SIGN_IDENTITY=-',
                       'CODE_SIGNING_REQUIRED=NO',
                       'ENABLE_BITCODE=NO',
                       'INDEX_ENABLE_DATA_STORE=NO',

--- a/project_future.py
+++ b/project_future.py
@@ -112,7 +112,7 @@ class XcodeTarget(ProjectTarget):
                       '-destination', self._destination]
                    + dir_override
                    + ['-sdk', self._sdk,
-                      'CODE_SIGN_IDENTITY=',
+                      'CODE_SIGN_IDENTITY=-',
                       'CODE_SIGNING_REQUIRED=NO',
                       'ENABLE_BITCODE=NO',
                       'INDEX_ENABLE_DATA_STORE=NO',


### PR DESCRIPTION
I noticed by looking that the build logs produced by Xcode that
`CODE_SIGN_IDENTITY` is never set to "", it's almost always "-" by
default.