### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/common.py
+++ b/common.py
@@ -12,6 +12,7 @@
 # ===----------------------------------------------------------------------===
 
 """A library containing common utility functionality."""
+from __future__ import print_function
 
 import multiprocessing
 import os
@@ -21,6 +22,11 @@ import signal
 import subprocess
 import sys
 import shlex
+
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
 
 DEFAULT_EXECUTE_TIMEOUT = 10*60
 
@@ -270,7 +276,7 @@ def shell_join(command):
 
 def debug_print(s, stderr=sys.stderr):
     """Print a string to stderr and flush."""
-    print >>stderr, s
+    print(s, file=stderr)
     stderr.flush()
 
 

--- a/project.py
+++ b/project.py
@@ -26,6 +26,11 @@ import argparse
 
 import common
 
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 swift_branch = None
 
 
@@ -512,7 +517,7 @@ def evaluate_predicate(element, predicate):
     # pylint: disable=I0011,W0122,W0123
     for key in element:
         if isinstance(element[key], basestring):
-            exec key + ' = """' + element[key] + '"""'
+            exec(key + ' = """' + element[key] + '"""')
     return eval(predicate)
 
 

--- a/project_future.py
+++ b/project_future.py
@@ -27,6 +27,11 @@ import shlex
 
 import common
 
+try:
+    basestring        # Python 2
+except NameError:
+    basestring = str  # Python 3
+
 swift_branch = None
 
 
@@ -553,7 +558,7 @@ def evaluate_predicate(element, predicate):
     # pylint: disable=I0011,W0122,W0123
     for key in element:
         if isinstance(element[key], basestring):
-            exec key + ' = """' + element[key] + '"""'
+            exec(key + ' = """' + element[key] + '"""')
     return eval(predicate)
 
 

--- a/reproduce.py
+++ b/reproduce.py
@@ -27,6 +27,11 @@ import sys
 
 import common
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__.split('\n')[0])


### PR DESCRIPTION
### Pull Request Description

Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run __futurize --stage1__ http://python-future.org/futurize_cheatsheet.html

Python 3 syntax compatibility does __not__ mean that the port is complete.  More work may be required to complete the port to Python 3.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [X] be an *Xcode* or *swift package manager* project
- [X] support building on either Linux or macOS
- [X] target Linux, macOS, or iOS/tvOS/watchOS device
- [X] be contained in a publicly accessible git repository
- [X] maintain a project branch that builds against Swift 3.0 compatibility mode
      or Swift 4.0 and passes any unit tests
- [X] have maintainers who will commit to resolve issues in a timely manner
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [X] add value not already included in the suite
- [X] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [X] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
