### PR TITLE
Remove 3.1 configuration of ProcedureKit

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1385,10 +1385,6 @@
       {
         "version": "3.0",
         "commit": "d6389ea98ec2e0d17ab368f40045bfe48622ac67"
-      },
-      {
-        "version": "3.1",
-        "commit": "46bdfdf2910acc84e58ed686df14a46a5cbc61f4"
       }
     ],
     "platforms": [
@@ -1400,76 +1396,28 @@
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "platform=macOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6618"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6618"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6618"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6618"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1482,14 +1430,6 @@
             "3.0": {
               "branch": {
                 "swift-4.0-branch": "rdar://35814436"
-              }
-            },
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.1-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6618",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-6618"
               }
             }
           }


### PR DESCRIPTION
These have been xfailed for some time now, and an updated hash has
not been provided. This removes the 3.1 configuration and associated
xfails.

See https://bugs.swift.org/browse/SR-6618