### PR TITLE
added xswift groups of projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -632,6 +632,35 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/masters3d/xswift.git",
+    "path": "exercism-xswift",
+    "branch": "do-not-delete-pre-4.2-compatibility",
+    "maintainer": "cheyo@masters3d.com",
+    "compatibility": [
+      {
+        "version": "4.0",
+        "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
+      },
+      {
+        "version": "4.1",
+        "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "xswift.xcodeproj",
+        "target": "xswift",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      }
+    ]
+    },
+  {
+    "repository": "Git",
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",
@@ -2722,61 +2751,6 @@
     ]
   },
   {
-  "repository": "Git",
-  "url": "https://github.com/masters3d/xswift.git",
-  "path": "xswift",
-  "branch": "do-not-delete-pre-4.2-compatibility",
-  "maintainer": "cheyo@masters3d.com",
-  "compatibility": [
-    {
-      "version": "4.0",
-      "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
-    },
-    {
-      "version": "4.1",
-      "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
-    }
-  ],
-  "platforms": [
-    "Darwin"
-  ],
-  "actions": [
-    {
-      "action": "BuildXcodeProjectTarget",
-      "project": "xswift.xcodeproj",
-      "target": "xswift-Package",
-      "destination": "generic/platform=macOS",
-      "configuration": "Release"
-    }
-  ]
-  },
-  {
-  "repository": "Git",
-  "url": "https://github.com/exercism/swift.git",
-  "path": "xswift",
-  "branch": "master",
-  "maintainer": "cheyo@masters3d.com",
-  "compatibility": [
-    {
-      "version": "4.2",
-      "commit": "ce9509e301f0661b0e9758f5cef23edd1d1bb50e"
-    }
-  ],
-  "platforms": [
-    "Darwin",
-    "Linux"
-  ],
-  "actions": [
-    {
-      "action": "BuildSwiftPackage",
-      "configuration": "release"
-    },
-    {
-      "action": "TestSwiftPackage"
-    }
-  ]
-  },
-  {
     "repository": "Git",
     "url": "https://github.com/vapor/vapor.git",
     "path": "vapor",
@@ -2808,5 +2782,31 @@
 	}
       }
     ]
-  }
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/exercism/swift.git",
+    "path": "xswift",
+    "branch": "master",
+    "maintainer": "cheyo@masters3d.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "ce9509e301f0661b0e9758f5cef23edd1d1bb50e"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+    }
 ]

--- a/projects.json
+++ b/projects.json
@@ -655,7 +655,21 @@
         "project": "xswift.xcodeproj",
         "target": "xswift",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release", 
+        "xfail": {
+           "compatibility": {
+             "4.0": {
+               "branch": {
+                 "master": "https://bugs.swift.org/browse/SR-8307"
+               }
+             },
+             "4.1": {
+               "branch": {
+                 "master": "https://bugs.swift.org/browse/SR-8307"
+               }
+             }
+           }
+         }
       }
     ]
     },
@@ -2802,7 +2816,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release", 
+        "xfail": {
+           "compatibility": {
+             "4.2": {
+               "branch": {
+                 "master": "https://bugs.swift.org/browse/SR-8307"
+               }
+             }
+           }
+         }
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -632,6 +632,41 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/exercism/swift.git",
+    "path": "exercism-swift",
+    "branch": "master",
+    "maintainer": "cheyo@masters3d.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release", 
+        "xfail": {
+           "compatibility": {
+             "4.2": {
+               "branch": {
+                 "master": "https://bugs.swift.org/browse/SR-8307"
+               }
+             }
+           }
+         }
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/masters3d/xswift.git",
     "path": "exercism-xswift",
     "branch": "do-not-delete-pre-4.2-compatibility",
@@ -2796,40 +2831,5 @@
 	}
       }
     ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/exercism/swift.git",
-    "path": "exercism-swift",
-    "branch": "master",
-    "maintainer": "cheyo@masters3d.com",
-    "compatibility": [
-      {
-        "version": "4.2",
-        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
-      }
-    ],
-    "platforms": [
-      "Darwin",
-      "Linux"
-    ],
-    "actions": [
-      {
-        "action": "BuildSwiftPackage",
-        "configuration": "release", 
-        "xfail": {
-           "compatibility": {
-             "4.2": {
-               "branch": {
-                 "master": "https://bugs.swift.org/browse/SR-8307"
-               }
-             }
-           }
-         }
-      },
-      {
-        "action": "TestSwiftPackage"
-      }
-    ]
-    }
+  }
 ]

--- a/projects.json
+++ b/projects.json
@@ -2792,7 +2792,7 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "ce9509e301f0661b0e9758f5cef23edd1d1bb50e"
+        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -2723,6 +2723,35 @@
   },
   {
   "repository": "Git",
+  "url": "https://github.com/masters3d/xswift.git",
+  "path": "xswift",
+  "branch": "do-not-delete-pre-4.2-compatibility",
+  "maintainer": "cheyo@masters3d.com",
+  "compatibility": [
+    {
+      "version": "4.0",
+      "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
+    },
+    {
+      "version": "4.1",
+      "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
+    }
+  ],
+  "platforms": [
+    "Darwin"
+  ],
+  "actions": [
+    {
+      "action": "BuildXcodeProjectTarget",
+      "project": "xswift.xcodeproj",
+      "target": "xswift-Package",
+      "destination": "generic/platform=macOS",
+      "configuration": "Release"
+    }
+  ]
+  },
+  {
+  "repository": "Git",
   "url": "https://github.com/exercism/swift.git",
   "path": "xswift",
   "branch": "master",

--- a/projects.json
+++ b/projects.json
@@ -2800,7 +2800,7 @@
   {
     "repository": "Git",
     "url": "https://github.com/exercism/swift.git",
-    "path": "xswift",
+    "path": "exercism-swift",
     "branch": "master",
     "maintainer": "cheyo@masters3d.com",
     "compatibility": [

--- a/projects.json
+++ b/projects.json
@@ -2722,6 +2722,32 @@
     ]
   },
   {
+  "repository": "Git",
+  "url": "https://github.com/exercism/swift.git",
+  "path": "xswift",
+  "branch": "master",
+  "maintainer": "cheyo@masters3d.com",
+  "compatibility": [
+    {
+      "version": "4.2",
+      "commit": "ce9509e301f0661b0e9758f5cef23edd1d1bb50e"
+    }
+  ],
+  "platforms": [
+    "Darwin",
+    "Linux"
+  ],
+  "actions": [
+    {
+      "action": "BuildSwiftPackage",
+      "configuration": "release"
+    },
+    {
+      "action": "TestSwiftPackage"
+    }
+  ]
+  },
+  {
     "repository": "Git",
     "url": "https://github.com/vapor/vapor.git",
     "path": "vapor",


### PR DESCRIPTION
### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      or Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
`local packages` 
- [x] be licensed with one of the following permissive licenses:
	* MIT
- [ ] pass `./project_precommit_check` script run

I need 4.2 for the local packages.  This project is using the 4.2 `local packages` feature. The sub-projects are 4.0 compatible but we use a bash script to test them individually.  

I guess we could use 4.2 to create the xcode project  but then I do not know how to specify the action to only be performed on for only a certain language.


