### PR TITLE
Remove tests that fail with Swift 3 expression type checking support …

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -354,10 +354,6 @@
     "maintainer": "rommel.estropia@gmail.com",
     "compatibility": [
       {
-        "version": "3.2",
-        "commit": "e314db8f56b83f2cc761a70cdfc3b823b9815c03"
-      },
-      {
         "version": "4.0",
         "commit": "83e6082c5646c5eb4d3130ce575ab858df168c59"
       }
@@ -388,12 +384,6 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
-            "3.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7908",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7908"
-              }
-            },
             "4.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7908",
@@ -411,12 +401,6 @@
         "configuration": "Release",
         "xfail": {
           "compatibility": {
-            "3.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7908",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7908"
-              }
-            },
             "4.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-7908",
@@ -579,10 +563,6 @@
     "maintainer": "ankur.patel@ymail.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "c0dd3c0f8cd5fa12f8b433f3f2e3e50fa7debdf5"
-      },
-      {
         "version": "4.0",
         "commit": "433d4ba9a3bec8aa739f05cb8505527aab7a30e7"
       }
@@ -643,10 +623,6 @@
       {
         "version": "4.0",
         "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
-      },
-      {
-        "version": "3.1",
-        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
       }
     ],
     "platforms": [
@@ -921,98 +897,6 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/kickstarter/Kickstarter-ReactiveExtensions",
-    "path": "Kickstarter-ReactiveExtensions",
-    "branch": "master",
-    "maintainer": "stephen@stephencelis.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "732eab9da730699f264dceb4f423586754191d67"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "ReactiveExtensions.xcodeproj",
-        "scheme": "ReactiveExtensions-iOS",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "ReactiveExtensions.xcodeproj",
-        "scheme": "ReactiveExtensions-TestHelpers-iOS",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "ReactiveExtensions.xcodeproj",
-        "scheme": "ReactiveExtensions-TestHelpers-tvOS",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "ReactiveExtensions.xcodeproj",
-        "scheme": "ReactiveExtensions-tvOS",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/onevcat/Kingfisher.git",
-    "path": "Kingfisher",
-    "branch": "master",
-    "maintainer": "onev@onevcat.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "5cfa0dd5c9fc48e1c31f574ad8eaa31a3a9d4003"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-macOS",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-tvOS",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-watchOS",
-        "destination": "generic/platform=watchOS",
-        "configuration": "Release"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/IBM-Swift/Kitura.git",
     "path": "Kitura",
     "branch": "master",
@@ -1134,10 +1018,6 @@
     "path": "Moya",
     "branch": "master",
     "compatibility": [
-      {
-        "version": "3.1",
-        "commit": "c4e58ee23db4aaec944505a2f7b001a89b602d7d"
-      },
       {
         "version": "4.0.3",
         "commit": "4b3ff7e7ddd87c0ce73b39b5390c045fe1a8d4af"
@@ -1356,10 +1236,6 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "d69c8e6f9942c098e589a75162d3196dec183929"
-      },
-      {
         "version": "4.0.3",
         "commit": "fe78418de7757d100c94f702e8effb5e7b8e93b8"
       }
@@ -1454,18 +1330,6 @@
     "branch": "master",
     "maintainer": "mxcl@me.com",
     "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "63ccb34a3d2834b7b08ce2014536344966399668"
-      },
-      {
-        "version": "3.1",
-        "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
-      },
-      {
-        "version": "3.2",
-        "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
-      },
       {
         "version": "4.0.3",
         "commit": "c538a244b110389483c71d5801f7944e042b5b7b"
@@ -1881,47 +1745,11 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/RxSwiftCommunity/RxDataSources",
-    "path": "RxDataSources",
-    "branch": "master",
-    "maintainer": "krunoslav.zaher@gmail.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "c06ebe2207ed3a74d69a9d9b9bb59b48b64a09b4"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeProjectTarget",
-        "project": "Pods/Pods.xcodeproj",
-        "target": "Pods-RxDataSources",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectTarget",
-        "project": "Pods/Pods.xcodeproj",
-        "target": "Pods-Example",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/ReactiveX/RxSwift.git",
     "path": "RxSwift",
     "branch": "master",
     "maintainer": "krunoslav.zaher@gmail.com",
     "compatibility": [
-      {
-        "version": "3.1",
-        "commit": "102424379fb8d6c69b33b95c67504679042f44cc"
-      },
       {
         "version": "4.0.3",
         "commit": "3e848781c7756accced855a6317a4c2ff5e8588b"
@@ -2123,87 +1951,6 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/daltoniam/Starscream",
-    "path": "Starscream",
-    "branch": "master",
-    "maintainer": "daltoniam@gmail.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "13859364e33368687a5ee0c9cc0d5782e4212b66"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
-        "scheme": "Starscream",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
-        "scheme": "StarscreamOSX",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
-        "scheme": "StarscreamTv",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
-        "scheme": "Starscream",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
-        "scheme": "StarscreamOSX",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
-        "scheme": "StarscreamTv",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "Starscream.xcodeproj",
-        "scheme": "Starscream",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "Starscream.xcodeproj",
-        "scheme": "StarscreamOSX",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "Starscream.xcodeproj",
-        "scheme": "StarscreamTv",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/mattt/Surge",
     "path": "Surge",
     "branch": "master",
@@ -2223,52 +1970,6 @@
         "project": "Surge.xcodeproj",
         "scheme": "Surge",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/malcommac/SwiftDate",
-    "path": "SwiftDate",
-    "branch": "master",
-    "maintainer": "me@danielemargutti.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "b8a6ace0b4a419d377886615ece14a3f259323fc"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_iOS",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_macOS",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_tvOS",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_watchOS",
-        "destination": "generic/platform=watchOS",
         "configuration": "Release"
       }
     ]
@@ -2323,70 +2024,6 @@
       },
       {
         "action": "TestSwiftPackage"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/SwifterSwift/SwifterSwift.git",
-    "path": "SwifterSwift",
-    "branch": "master",
-    "maintainer": "omaralbeik@gmail.com",
-    "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "66e5237f055f72f725536cd3322f7f6483e7aeed"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift iOS",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift macOS",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift tvOS",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift watchOS",
-        "destination": "generic/platform=watchOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift iOSTests",
-        "destination": "platform=iOS Simulator,name=iPhone 7,OS=10.2"
-      },
-      {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift tvOSTests",
-        "destination": "platform=tvOS Simulator,name=Apple TV 1080p"
-      },
-      {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "SwifterSwift.xcworkspace",
-        "scheme": "SwifterSwift macOSTests",
-        "destination": "platform=macOS"
       }
     ]
   },
@@ -2636,10 +2273,6 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "d451d956fb31f0ca5d76940c0b1db46b8c74a089"
-      },
-      {
         "version": "4.0.3",
         "commit": "3ede6efaa9d2b2502ad069b16215513f3e515119"
       }
@@ -2677,10 +2310,6 @@
     "path": "siesta",
     "branch": "master",
     "compatibility": [
-      {
-        "version": "3.0",
-        "commit": "1665db77a35b0e5c60269825d2e9b4d6971b81b5"
-      },
       {
         "version": "4.0",
         "commit": "926127231446fc5c1c8c3236033914a4006ab9a2"

--- a/projects.json
+++ b/projects.json
@@ -897,6 +897,170 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/kickstarter/Kickstarter-ReactiveExtensions",
+    "path": "Kickstarter-ReactiveExtensions",
+    "branch": "master",
+    "maintainer": "stephen@stephencelis.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "732eab9da730699f264dceb4f423586754191d67"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-TestHelpers-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-TestHelpers-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/onevcat/Kingfisher.git",
+    "path": "Kingfisher",
+    "branch": "master",
+    "maintainer": "onev@onevcat.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "5cfa0dd5c9fc48e1c31f574ad8eaa31a3a9d4003"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Kingfisher.xcworkspace",
+        "scheme": "Kingfisher",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Kingfisher.xcworkspace",
+        "scheme": "Kingfisher-macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Kingfisher.xcworkspace",
+        "scheme": "Kingfisher-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Kingfisher.xcworkspace",
+        "scheme": "Kingfisher-watchOS",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/IBM-Swift/Kitura.git",
     "path": "Kitura",
     "branch": "master",
@@ -1745,6 +1909,56 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/RxSwiftCommunity/RxDataSources",
+    "path": "RxDataSources",
+    "branch": "master",
+    "maintainer": "krunoslav.zaher@gmail.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "c06ebe2207ed3a74d69a9d9b9bb59b48b64a09b4"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Pods/Pods.xcodeproj",
+        "target": "Pods-RxDataSources",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Pods/Pods.xcodeproj",
+        "target": "Pods-Example",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/ReactiveX/RxSwift.git",
     "path": "RxSwift",
     "branch": "master",
@@ -1951,6 +2165,168 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/daltoniam/Starscream",
+    "path": "Starscream",
+    "branch": "master",
+    "maintainer": "daltoniam@gmail.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "13859364e33368687a5ee0c9cc0d5782e4212b66"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
+        "scheme": "Starscream",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
+        "scheme": "StarscreamOSX",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/AutobahnTest/Autobahn.xcodeproj",
+        "scheme": "StarscreamTv",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
+        "scheme": "Starscream",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
+        "scheme": "StarscreamOSX",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "examples/SimpleTest/SimpleTest.xcodeproj",
+        "scheme": "StarscreamTv",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "Starscream.xcodeproj",
+        "scheme": "Starscream",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "Starscream.xcodeproj",
+        "scheme": "StarscreamOSX",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "Starscream.xcodeproj",
+        "scheme": "StarscreamTv",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8174"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/mattt/Surge",
     "path": "Surge",
     "branch": "master",
@@ -1970,6 +2346,52 @@
         "project": "Surge.xcodeproj",
         "scheme": "Surge",
         "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/malcommac/SwiftDate",
+    "path": "SwiftDate",
+    "branch": "master",
+    "maintainer": "me@danielemargutti.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "b8a6ace0b4a419d377886615ece14a3f259323fc"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "scheme": "SwiftDate_iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "scheme": "SwiftDate_macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "scheme": "SwiftDate_tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "scheme": "SwiftDate_watchOS",
+        "destination": "generic/platform=watchOS",
         "configuration": "Release"
       }
     ]


### PR DESCRIPTION
…removed.

Most of these are tested with 4.x as well, and remain. I've wholesale
deleted the ones that are only tested with 3.x, but could revert those
parts of XFAIL them instead if there is a reason to do so. My thoughts
are that it's easy to replace these when we get hashes to text 4.x with.
