### PR TITLE
Update canonical hash for building GRDB with Swift 4 mode.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -637,17 +637,9 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "4.1",
-        "commit": "27e94c211d1e6b129ecfa9e73d5846717ceed4e8"
-      },
-      {
         "version": "4.0",
-        "commit": "58e05d13d1e5b42c70c6dd36d64cf1a44fabbb45"
+        "commit": "f121c6b1393aacf6d1956ea9edf0dd1e9c34977f"
       },
-      {
-        "version": "3.1",
-        "commit": "ba8375adb120a9c67de8cc8f420c934581a82e3b"
-      }
     ],
     "platforms": [
       "Darwin"

--- a/projects.json
+++ b/projects.json
@@ -639,7 +639,7 @@
       {
         "version": "4.0",
         "commit": "f121c6b1393aacf6d1956ea9edf0dd1e9c34977f"
-      },
+      }
     ],
     "platforms": [
       "Darwin"


### PR DESCRIPTION
This updates the hash for GRDB to build with trip of master of GRDB.

Also:

- Remove building for Swift 3 (not supported in Swift 5)
- Removes redundant building for 4.1 and 4.0, as they are identical from a testing perspective.