### PR TITLE
Update hash for IBAnimatableApp to build with Swift 4

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -733,8 +733,8 @@
     "maintainer": "JakeLinAu@gmail.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "b428dd736d9418e03a1fad19d89f2c9b99389227"
+        "version": "4.0",
+        "commit": "c81532d38ee03e76f86e5b1b40dcd4cfad153fee"
       }
     ],
     "platforms": [


### PR DESCRIPTION
- Update to tip of `master` for building IBAnimatableApp
- Drop building Swift 3 mode (project now builds with Swift 4)