### PR TITLE
For JSQCoreDataKit drop building Swift 3, and update to tip for Swift 4

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -766,7 +766,7 @@
     "compatibility": [
       {
         "version": "4.0",
-        "commit": "fccbaf7e8726e5129935d3dd4da401938293ee2e"
+        "commit": "772920fef79fac26cf7a2c3d58f32e739249c5d5"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -766,11 +766,7 @@
     "compatibility": [
       {
         "version": "4.0",
-        "commit": "c48fed73909a295d9aa80e22a4a0e26a04301723"
-      },
-      {
-        "version": "3.0",
-        "commit": "5e8b8327fc87c008e718a2c1aa0a78b7eac16a53"
+        "commit": "fccbaf7e8726e5129935d3dd4da401938293ee2e"
       }
     ],
     "platforms": [


### PR DESCRIPTION
- Drop building Swift 3 variant of this project.
- Update to tip of `master` for building project in Swift 4 mode.