### PR TITLE
Update hash to build SwiftDate with Swift 4

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2235,8 +2235,8 @@
     "maintainer": "me@danielemargutti.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "b8a6ace0b4a419d377886615ece14a3f259323fc"
+        "version": "4.0",
+        "commit": "744a8ce947f71e951e9f0f240b07d1a4f1f8b84e"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -2245,28 +2245,28 @@
     "actions": [
       {
         "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "project": "SwiftDate.xcodeproj",
         "scheme": "SwiftDate_iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "project": "SwiftDate.xcodeproj",
         "scheme": "SwiftDate_macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "project": "SwiftDate.xcodeproj",
         "scheme": "SwiftDate_tvOS",
         "destination": "generic/platform=tvOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
-        "project": "SwiftDate/SwiftDate.xcodeproj",
+        "project": "SwiftDate.xcodeproj",
         "scheme": "SwiftDate_watchOS",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"

--- a/projects.json
+++ b/projects.json
@@ -2246,28 +2246,28 @@
       {
         "action": "BuildXcodeProjectScheme",
         "project": "SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_iOS",
+        "scheme": "SwiftDate-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_macOS",
+        "scheme": "SwiftDate-macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_tvOS",
+        "scheme": "SwiftDate-tvOS",
         "destination": "generic/platform=tvOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "SwiftDate.xcodeproj",
-        "scheme": "SwiftDate_watchOS",
+        "scheme": "SwiftDate-watchOS",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"
       }


### PR DESCRIPTION
- Drop building SwiftDate in Swift 3 mode.
- Update to tip of `master` for SwiftDate when building in Swift 4 mode.