### PR TITLE
Dropping building SwiftGraph in 3.0 mode.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2281,12 +2281,8 @@
     "maintainer": "david@oaksnow.com",
     "compatibility": [
       {
-        "version": "3.1",
-        "commit": "07b088eef5cb883e5544ea4d2e9a1338318f0596"
-      },
-      {
-        "version": "4.0.3",
-        "commit": "639e382b21975d900afadbcfaf02ff50c90409b7"
+        "version": "4.0",
+        "commit": "6c8c5d699db17f3726776656a09f058bb29d76ec"
       }
     ],
     "platforms": [


### PR DESCRIPTION
- Drop building SwiftGraph in 3.0 mode
- Updating to building tip-of-master for SwiftGraph in 4.0 mode