### PR TITLE
Enable CoreStore tvOS project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -377,7 +377,7 @@
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -378,22 +378,6 @@
         "scheme": "CoreStore tvOS",
         "destination": "generic/platform=tvOS",
         "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7908",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7908"
-              }
-            },
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-7908",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-7908"
-              }
-            }
-          }
-        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
After updating the bots to Xcode 10 beta 3, we started seeing CoreStore tvOS project passing again. 

https://bugs.swift.org/browse/SR-7908