### PR TITLE
Also xfail Swift Package builds on 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -182,7 +182,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -195,7 +196,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -520,7 +522,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -626,7 +629,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1064,7 +1068,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1098,7 +1103,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1133,7 +1139,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1254,7 +1261,8 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1339,7 +1347,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1488,7 +1497,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -1825,7 +1835,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -2273,7 +2284,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }


### PR DESCRIPTION
Some Swift Package Manager actions have been failing because of a recent change to manifest file requirements. These builds were xfailed when tested against master already in #213. This PR adds the xfail when tested against swift-4.2-branch.

See also https://bugs.swift.org/browse/SR-8234