### PR TITLE
Restore the KickStarter-ReactiveExtensions and RxDataSources projects.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -885,7 +885,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
+                "master": "https://bugs.swift.org/browse/SR-8270"
               }
             }
           }
@@ -901,7 +901,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
+                "master": "https://bugs.swift.org/browse/SR-8270"
               }
             }
           }
@@ -917,7 +917,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
+                "master": "https://bugs.swift.org/browse/SR-8270"
               }
             }
           }
@@ -933,7 +933,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
+                "master": "https://bugs.swift.org/browse/SR-8270"
               }
             }
           }
@@ -1867,7 +1867,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8271",
+                "master": "https://bugs.swift.org/browse/SR-8271"
               }
             }
           }
@@ -1883,7 +1883,7 @@
           "compatibility": {
             "3.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8271",
+                "master": "https://bugs.swift.org/browse/SR-8271"
               }
             }
           }

--- a/projects.json
+++ b/projects.json
@@ -861,6 +861,88 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/kickstarter/Kickstarter-ReactiveExtensions",
+    "path": "Kickstarter-ReactiveExtensions",
+    "branch": "master",
+    "maintainer": "stephen@stephencelis.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "732eab9da730699f264dceb4f423586754191d67"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8270",
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-TestHelpers-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8270",
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-TestHelpers-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8270",
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectScheme",
+        "project": "ReactiveExtensions.xcodeproj",
+        "scheme": "ReactiveExtensions-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8270",
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/onevcat/Kingfisher.git",
     "path": "Kingfisher",
     "branch": "master",
@@ -1756,6 +1838,56 @@
       },
       {
         "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/RxSwiftCommunity/RxDataSources",
+    "path": "RxDataSources",
+    "branch": "master",
+    "maintainer": "krunoslav.zaher@gmail.com",
+    "compatibility": [
+      {
+        "version": "3.0",
+        "commit": "c06ebe2207ed3a74d69a9d9b9bb59b48b64a09b4"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Pods/Pods.xcodeproj",
+        "target": "Pods-RxDataSources",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8271",
+              }
+            }
+          }
+        }
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Pods/Pods.xcodeproj",
+        "target": "Pods-Example",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8271",
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
...but mark them as XFAILed for 3.0. We need to get a good hash for
Swift 4 and remove the 3.0 ones (and XFAILS).
