### PR TITLE
Add Fluent project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -603,7 +603,7 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "86eb8812415fa33674793e37482a9e6455be0a0f"
+        "commit": "270b6fa372f03809b9795e8f8b9d1c31267a0ff3"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -715,7 +715,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8332"
+              }
+            }
+          }
+        }
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -708,15 +708,15 @@
         "version": "4.2",
         "commit": "270b6fa372f03809b9795e8f8b9d1c31267a0ff3"
       }
-     ],
-     "platforms": [
-       "Darwin"
-     ],
-     "actions": [
-       {
-         "action": "BuildSwiftPackage",
-         "configuration": "release"
-       }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      }
     ]
   },
   {

--- a/projects.json
+++ b/projects.json
@@ -596,6 +596,28 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/vapor/fluent",
+    "path": "fluent",
+    "branch": "master",
+    "maintainer": "tanner@vapor.codes",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "86eb8812415fa33674793e37482a9e6455be0a0f"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",


### PR DESCRIPTION
https://github.com/vapor/fluent

### Pull Request Description

Adds Fluent project

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 3.0 compatibility mode
      or Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run
```
PASS: fluent, 4.2, 86eb88, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- fluent checked successfully against Swift 4.2 ---
```