### PR TITLE
Updates ObjectMapper hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1290,8 +1290,8 @@
     "maintainer": "tristanhimmelman@gmail.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "eef27bfcfd201036a12992b6988e64a088fe7354"
+        "version": "4.2",
+        "commit": "ed1caa237b9742135996fefe3682b834bb394a6a"
       }
     ],
     "platforms": [
@@ -1303,68 +1303,28 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-Mac",
         "destination": "generic/platform=macOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-6690",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-6690"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

This new hash passes project_precommit_check when built against Xcode 10 Beta 3's Swift 4.2 compiler.

```
./project_precommit_check ObjectMapper --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating ObjectMapper Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking ObjectMapper platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode-10-beta-3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode-10-beta-3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "ObjectMapper"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-iOS, generic/platform=iOS
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-Mac, generic/platform=macOS
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-tvOS, generic/platform=tvOS
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-watchOS, generic/platform=watchOS
========================================
Action Summary:
     Passed: 4
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 4
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- ObjectMapper checked successfully against Swift 4.2 ---
```

It also removes the associated xfail which no longer applies: https://bugs.swift.org/browse/SR-6690
rdar://40863157