### PR TITLE
XFAIL SwiftNIO project for 4.2 - https://bugs.swift.org/browse/SR-8403

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2342,7 +2342,16 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8403"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
XFAIL'ing because it currently breaks Source Compatibility Suite runs.