### PR TITLE
Add run_sk_stress_test script to run the SourceKit stress tester over the source compatibility suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ swift-corelibs-foundation/
 swift-corelibs-libdispatch/
 swift-corelibs-xctest/
 swiftpm/
+swift-stress-tester/

--- a/cleanup
+++ b/cleanup
@@ -52,6 +52,7 @@ def main():
         'swift-corelibs-foundation',
         'swift-corelibs-libdispatch',
         'swift-corelibs-xctest',
+        'swift-stress-tester'
     ]
 
     if args.cleanup_cache:

--- a/common.py
+++ b/common.py
@@ -143,6 +143,12 @@ def set_swift_branch(branch):
     swift_branch = branch
 
 
+def set_default_execute_timeout(timeout):
+    """Override the default execute timeout"""
+    global DEFAULT_EXECUTE_TIMEOUT
+    DEFAULT_EXECUTE_TIMEOUT = timeout
+
+
 def clone_repos():
     """Clone Swift and dependencies in parallel.
 
@@ -299,7 +305,7 @@ class ExecuteCommandFailure(Exception):
                     self.returncode))
 
 
-def execute(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
+def execute(command, timeout=None,
             stdout=sys.stdout, stderr=sys.stderr,
             **kwargs):
     """Execute a given command with an optional timeout in seconds.
@@ -307,6 +313,8 @@ def execute(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
     >>> execute(['echo', 'Hello, World!'])
     0
     """
+    if timeout is None:
+        timeout = DEFAULT_EXECUTE_TIMEOUT
     shell_debug_print(command, stderr=stderr)
     returncode = 124  # timeout return code
     try:
@@ -320,13 +328,15 @@ def execute(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
     return returncode
 
 
-def check_execute_output(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
+def check_execute_output(command, timeout=None,
                          stdout=sys.stdout, stderr=sys.stderr, **kwargs):
     """Check execute a given command and return its output.
 
     >>> check_execute_output(['echo', 'Hello, World!'])
     'Hello, World!\\n'
     """
+    if timeout is None:
+        timeout = DEFAULT_EXECUTE_TIMEOUT
     shell_debug_print(command, stderr=stderr)
     try:
         with Timeout(timeout):
@@ -339,7 +349,7 @@ def check_execute_output(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
     return output
 
 
-def check_execute(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
+def check_execute(command, timeout=None,
                   sandbox_profile=None, max_retries=1,
                   stdout=sys.stdout, stderr=sys.stderr,
                   **kwargs):
@@ -348,6 +358,8 @@ def check_execute(command, timeout=DEFAULT_EXECUTE_TIMEOUT,
     >>> check_execute(['echo', 'Hello, World!'])
     0
     """
+    if timeout is None:
+        timeout = DEFAULT_EXECUTE_TIMEOUT
     if sandbox_profile:
         if platform.system() == 'Darwin':
             command = ['sandbox-exec', '-f', sandbox_profile] + command

--- a/projects.json
+++ b/projects.json
@@ -20,7 +20,8 @@
         "project": "AMScrollingNavbar.xcodeproj",
         "target": "AMScrollingNavbar",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -52,7 +53,8 @@
         "workspace": "Alamofire.xcworkspace",
         "scheme": "Alamofire macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -99,7 +101,8 @@
         "project": "AsyncNinja.xcodeproj",
         "scheme": "AsyncNinja",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestXcodeProjectScheme",
@@ -174,6 +177,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "debug",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -220,7 +224,8 @@
         "workspace": "BlueSocket.xcworkspace",
         "scheme": "Socket",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -252,7 +257,8 @@
         "workspace": "Chatto.xcworkspace",
         "scheme": "Chatto",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -265,7 +271,8 @@
         "workspace": "Chatto.xcworkspace",
         "scheme": "ChattoAdditions",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -316,7 +323,8 @@
         "project": "CleanroomLogger.xcodeproj",
         "scheme": "CleanroomLogger",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -368,7 +376,8 @@
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore OSX",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -439,7 +448,8 @@
         "workspace": "Cub.xcworkspace",
         "scheme": "Cub macOS Release [Double]",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -467,7 +477,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"
@@ -494,6 +505,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -552,7 +564,8 @@
         "project": "Dollar.xcodeproj",
         "scheme": "Dollar",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       }
     ]
   },
@@ -577,7 +590,8 @@
         "project": "Dwifft.xcodeproj",
         "target": "Dwifft",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -602,7 +616,8 @@
         "workspace": "Evergreen.xcworkspace",
         "scheme": "Evergreen",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -626,15 +641,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release", 
+        "tags": "sourcekit",
         "xfail": {
-           "compatibility": {
-             "4.2": {
-               "branch": {
-                 "master": "https://bugs.swift.org/browse/SR-8307"
-               }
-             }
-           }
-         }
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8307"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -703,6 +719,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.2": {
@@ -734,6 +751,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -769,6 +787,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit sourcekit-smoke",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -805,7 +824,8 @@
         "workspace": "IBAnimatable.xcworkspace",
         "scheme": "IBAnimatable",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -841,7 +861,8 @@
         "project": "JSQCoreDataKit.xcodeproj",
         "target": "JSQCoreDataKit-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestXcodeProjectScheme",
@@ -876,7 +897,8 @@
         "project": "JSQDataSourcesKit.xcodeproj",
         "target": "JSQDataSourcesKit-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestXcodeProjectScheme",
@@ -907,7 +929,8 @@
         "workspace": "KeychainAccess.xcworkspace",
         "scheme": "KeychainAccess",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -953,7 +976,8 @@
         "project": "Prelude.xcodeproj",
         "scheme": "Prelude-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -967,7 +991,8 @@
         "project": "Prelude.xcodeproj",
         "scheme": "Prelude-UIKit-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -1000,6 +1025,7 @@
         "scheme": "ReactiveExtensions-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {
@@ -1088,7 +1114,8 @@
         "workspace": "Kingfisher.xcworkspace",
         "scheme": "Kingfisher-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1125,7 +1152,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -1157,7 +1185,8 @@
         "project": "Kronos.xcodeproj",
         "target": "Kronos",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1210,6 +1239,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1244,6 +1274,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1279,6 +1310,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1322,7 +1354,8 @@
         "workspace": "ObjectMapper.xcworkspace",
         "scheme": "ObjectMapper-Mac",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1360,6 +1393,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {
@@ -1400,7 +1434,8 @@
         "project": "PinkyPromise.xcodeproj",
         "scheme": "PinkyPromise_macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildSwiftPackage",
@@ -1454,6 +1489,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1490,7 +1526,8 @@
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1519,6 +1556,7 @@
         "target": "ProcedureKitCloud",
         "destination": "platform=macOS",
         "configuration": "Release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {
@@ -1559,7 +1597,8 @@
         "project": "PromiseKit.xcodeproj",
         "target": "PromiseKit",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1603,6 +1642,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1639,7 +1679,8 @@
         "workspace": "ReLax.xcworkspace",
         "scheme": "ReLax",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -1671,7 +1712,8 @@
         "project": "ReSwift.xcodeproj",
         "scheme": "ReSwift-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -1710,7 +1752,8 @@
         "workspace": "ReactiveCocoa.xcworkspace",
         "scheme": "ReactiveCocoa-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1757,7 +1800,8 @@
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1802,6 +1846,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -1839,6 +1884,7 @@
         "target": "Pods-RxDataSources",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {
@@ -1888,7 +1934,8 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxSwift-macOS",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1916,7 +1963,8 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa-macOS",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1944,7 +1992,8 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxBlocking-macOS",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1972,7 +2021,8 @@
         "workspace": "Rx.xcworkspace",
         "scheme": "RxTests-macOS",
         "destination": "platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2008,7 +2058,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"
@@ -2035,6 +2086,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {
@@ -2066,6 +2118,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -2117,7 +2170,8 @@
         "project": "Starscream.xcodeproj",
         "scheme": "Starscream",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -2142,7 +2196,8 @@
         "project": "Surge.xcodeproj",
         "scheme": "Surge",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit sourcekit-smoke"
       }
     ]
   },
@@ -2174,7 +2229,8 @@
         "project": "SwiftDate.xcodeproj",
         "scheme": "SwiftDate-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -2211,7 +2267,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -2235,6 +2292,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -2278,7 +2336,8 @@
         "workspace": "SwifterSwift.xcworkspace",
         "scheme": "SwifterSwift-macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2332,7 +2391,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"
@@ -2367,7 +2427,8 @@
         "project": "SwiftyStoreKit.xcodeproj",
         "target": "SwiftyStoreKit_macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -2397,6 +2458,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.1": {
@@ -2431,6 +2493,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.1": {
@@ -2471,7 +2534,8 @@
         "workspace": "Kommander.xcworkspace",
         "scheme": "Kommander macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2510,7 +2574,8 @@
         "workspace": "LaunchScreenSnapshot.xcworkspace",
         "scheme": "LaunchScreenSnapshot",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -2542,7 +2607,8 @@
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -2597,7 +2663,8 @@
         "workspace": "PanelKit.xcworkspace",
         "scheme": "PanelKit",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2642,7 +2709,8 @@
         "project": "Siesta.xcodeproj",
         "target": "Siesta macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -2656,7 +2724,8 @@
         "project": "Siesta.xcodeproj",
         "target": "SiestaUI macOS",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "tags": "sourcekit"
       }
     ]
   },
@@ -2680,6 +2749,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit",
         "xfail": {
           "compatibility": {
             "3.0": {

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -1,0 +1,485 @@
+#!/usr/bin/env python
+# ===--- run_sk_stress_test -----------------------------------------------===
+#
+#  This source file is part of the Swift.org open source project
+#
+#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+#  Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#  See https://swift.org/LICENSE.txt for license information
+#  See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===----------------------------------------------------------------------===
+
+"""A run script to be executed as a Jenkins build step."""
+
+from __future__ import print_function
+import sys
+import os
+import re
+import json
+import subprocess
+import argparse
+import platform
+
+import common
+
+script_dir = os.path.abspath(os.path.dirname(__file__))
+
+
+def main():
+    if platform.system() != 'Darwin':
+        raise common.UnsupportedPlatform
+
+    common.debug_print('** RUN SOURCEKIT STRESS TESTER **')
+    os.chdir(os.path.dirname(__file__))
+
+    args = parse_args()
+    common.set_swift_branch(args.swift_branch)
+    workspace = common.private_workspace('.')
+
+    if not args.skip_tools_clone:
+        common.clone_repos()
+
+    if not args.skip_stress_tester_clone:
+        clone_stress_tester(workspace, args.swift_branch)
+
+    if not args.skip_tools_build:
+        build_swift_toolchain(workspace, args)
+
+    if not args.skip_stress_tester_build:
+        build_stress_tester(workspace, args)
+
+    if not args.skip_runner:
+        if not execute_runner(workspace, args):
+            return 1
+
+    return 0
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('swift_branch')
+    parser.add_argument('--sandbox', action='store_true')
+    parser.add_argument('--projects',
+                        metavar='PATH',
+                        help='JSON project file',
+                        default='projects.json')
+    parser.add_argument('--filter-by-tag',
+                        metavar='TAG',
+                        help='Only run project actions with the given tag',
+                        default='sourcekit')
+    parser.add_argument('--sourcekit-xfails',
+                        metavar='PATH',
+                        help='JSON file specifying expected sourcekit failures',
+                        default='sourcekit-xfails.json')
+    parser.add_argument('--gen-sourcekit-xfails',
+                        metavar='PATH',
+                        help='write any sourcekit failures encountered out to <PATH> in JSON; if --sourcekit-xfails is also specified, the union of its contents and any unexpected failures will be written instead')
+    parser.add_argument('--verbose',
+                        action='store_true')
+    parser.add_argument('--assertions',
+                        help='Build Swift with asserts',
+                        action='store_true')
+    parser.add_argument('--debug',
+                        help='Build Swift in debug mode',
+                        action='store_true')
+    parser.add_argument('--swiftc',
+                        metavar='PATH',
+                        help='swiftc executable')
+    parser.add_argument('--skip-tools-build',
+                        action='store_true')
+    parser.add_argument('--skip-stress-tester-build',
+                        action='store_true')
+    parser.add_argument('--skip-ci-steps',
+                        action='store_true')
+    parser.add_argument('--skip-tools-clone',
+                        action='store_true')
+    parser.add_argument('--skip-stress-tester-clone',
+                        action='store_true')
+    parser.add_argument('--skip-runner',
+                        action='store_true')
+    parser.add_argument('--add-swift-flags',
+                        metavar='FLAGS',
+                        help='add flags to each Swift invocation (note: field '
+                             'names from projects.json enclosed in {} will be '
+                             'replaced with their value)',
+                        default='')
+    parser.add_argument('--add-xcodebuild-flags',
+                        metavar='FLAGS',
+                        help='add flags to each xcodebuild invocation (note: field '
+                             'names from projects.json enclosed in {} will be '
+                             'replaced with their value)',
+                        default='')
+    return parser.parse_args()
+
+
+def get_swiftc_path(workspace, swiftc):
+    swiftc_path = (
+        swiftc if swiftc else
+        os.path.join(workspace, 'build/compat_macos/install/toolchain/usr/bin/swiftc')
+    )
+    return swiftc_path
+
+def get_stress_test_path(workspace):
+    return os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester/.build/release/sk-stress-test')
+
+def get_sandbox_profile_flags():
+    return [
+        '--sandbox-profile-xcodebuild',
+        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_xcodebuild.sb',
+        '--sandbox-profile-package',
+        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_package.sb'
+    ]
+
+def get_sandbox_profile_flags_test():
+    return [
+        '--sandbox-profile-xcodebuild',
+        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_xcodebuild.sb',
+        '--sandbox-profile-package',
+        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_test.sb'
+    ]
+
+def clone_stress_tester(workspace, swift_branch):
+    clone_cmd = [
+        'git','clone', '-q', '-b', swift_branch, '--recursive',
+        'https://github.com/apple/swift-stress-tester',
+        '{}/swift-stress-tester'.format(workspace)
+    ]
+    common.check_execute(clone_cmd, timeout=9999999)
+    
+
+def execute_runner(workspace, args):
+    swiftc_path = get_swiftc_path(workspace, args.swiftc)
+    wrapper_path = os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester/.build/release/sk-swiftc-wrapper')
+    wrapper_link = os.path.join(os.path.dirname(swiftc_path), 'sk-swiftc-wrapper')
+
+    # copy stress tester wrapper alongside the underlying swiftc
+    # as swiftpm seems to look for other tools relative to the provided swiftc
+    if os.path.lexists(wrapper_link):
+        os.unlink(wrapper_link)
+    os.symlink(wrapper_path, wrapper_link)
+
+    extra_runner_args = []
+    if args.sandbox:
+        extra_runner_args += get_sandbox_profile_flags()
+
+    if args.add_swift_flags:
+        extra_runner_args += ['--add-swift-flags=%s' % args.add_swift_flags]
+
+    if args.add_xcodebuild_flags:
+        extra_runner_args += ['--add-xcodebuild-flags=%s' % args.add_xcodebuild_flags]
+
+    if args.filter_by_tag:
+        extra_runner_args += ['--include-actions', '"tags" in locals() and "{}" in tags.split()'.format(args.filter_by_tag)]
+
+
+    failure_manager = FailureManager(args.sourcekit_xfails, args.swift_branch)
+    runner = StressTesterRunner(wrapper_link, get_stress_test_path(workspace), swiftc_path, failure_manager)
+    passed = runner.run(args.projects, args.swift_branch, extra_runner_args)
+
+    # output failures as json if requested and the the underlying compatibility run succeeded.
+    if not runner.compat_runner_failed and args.gen_sourcekit_xfails:
+        failure_manager.write_failures(args.gen_sourcekit_xfails, update=True)
+    return passed
+
+
+def build_swift_toolchain(workspace, args):
+    build_command = [
+        os.path.join(workspace, 'swift/utils/build-script'),
+        '--debug' if args.debug else '--release',
+        '--assertions' if args.assertions else '--no-assertions',
+        '--build-ninja',
+        '--llbuild',
+        '--swiftpm',
+        '--ios',
+        '--tvos',
+        '--watchos',
+        '--skip-build-benchmarks',
+        '--build-subdir=compat_macos',
+        '--compiler-vendor=apple',
+        '--',
+        '--darwin-install-extract-symbols',
+        '--darwin-toolchain-alias=swift',
+        '--darwin-toolchain-bundle-identifier=org.swift.compat-macos',
+        '--darwin-toolchain-display-name-short=Swift Development Snapshot'
+        '--darwin-toolchain-display-name=Swift Development Snapshot',
+        '--darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT',
+        '--darwin-toolchain-version=3.999.999',
+        '--install-llbuild',
+        '--install-swift',
+        '--install-swiftpm',
+        '--install-destdir={}/build/compat_macos/install'.format(workspace),
+        '--install-prefix=/toolchain/usr',
+        '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
+        '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
+        '--llvm-install-components=libclang;libclang-headers',
+        '--swift-install-components=compiler;clang-builtin-headers;stdlib;swift-syntax;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
+        '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
+        '--verbose-build',
+        '--reconfigure',
+    ]
+    common.check_execute(build_command, timeout=9999999)
+
+
+def build_stress_tester(workspace, args):
+    swiftc_path = get_swiftc_path(workspace, args.swiftc)
+    bin_dir = os.path.dirname(swiftc_path)
+    lib_dir = os.path.join(os.path.dirname(bin_dir), 'lib')
+    swift = os.path.join(bin_dir, 'swift')
+    
+    build_command = [
+        swift, 'build',
+        '--package-path', os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester'),
+        '-c', 'release',
+        '-Xswiftc', '-target', '-Xswiftc', 'x86_64-apple-macosx10.13',
+        # to pick up the sourcekitd framework
+        '-Xswiftc', '-Fsystem', '-Xswiftc', lib_dir,
+        '-Xlinker', '-rpath', '-Xlinker', lib_dir
+    ]
+    common.check_execute(build_command, timeout=999)
+
+class FailureKind(object):
+    """the kind of failure detected on a particular line of output."""
+    NONE = 1 
+    FAIL = 2
+    XFAIL = 3
+
+
+class FailureManager(object):
+    """parses and manages failures reported by the SourceKit stress tester."""
+
+    _error_matcher = re.compile(r'\[sk-stress-test\] error: (?P<failure>[^ ]+) invoking SourceKit request (?P<request>[^ ]+)(?: \((?P<refactoring>[^\)]+)\))? [oi]n .*/project_cache/(?P<file>.+\.swift)(?: a[ts] offset (?P<offset>\d+)(?: for length (?P<length>\d+))? with args:.*)?$')
+    _seen_matcher = re.compile(r'\[sk-stress-test\] Stress testing .*/project_cache/(?P<file>.+\.swift)(?: part \d+ of \d+):$')
+
+    def __init__(self, xfails_path, swift_branch):
+        self.swift_branch = swift_branch
+        self.xfails_path = xfails_path
+        self.xfails = self._load_applicable_xfails(xfails_path, swift_branch) if xfails_path else []
+        self.seen_files = []
+        self.expected = []
+        self.unexpected = []
+        self.unrecognized_errors = []
+
+    def process_line(self, line):
+        match = self._error_matcher.search(line)
+        if not match:
+            if line.startswith('[sk-stress-test] error:'):
+                self.unrecognized_errors.append(line)
+            else:
+                # keep track of files we actually stress test so we don't report unmatched xfails in files we didn't see
+                progress = self._seen_matcher.search(line)
+                if progress:
+                    self.seen_files.append(progress.groupdict()['file'])
+            return FailureKind.NONE, None
+
+        failure = {key: value for key, value in match.groupdict().items() if value is not None}
+        failure['branches'] = [self.swift_branch]
+
+        for key in ['offset', 'length']:
+            if key in failure:
+                failure[key] = int(failure[key])
+
+        if self._is_expected_failure(failure):
+            self.expected.append(failure)
+            return FailureKind.XFAIL, failure
+        
+        self.unexpected.append(failure)
+        return FailureKind.FAIL, failure
+
+    @property
+    def unmatched_xfails(self):
+        return [xfail for xfail in self.xfails if not xfail.get('_matched', False) and self._saw_matching_file(xfail.get('file'))]
+
+    def write_failures(self, path, update=False):
+        with open(path, 'w') as json_out:
+            failures = self.unexpected + (self.xfails if update and self.xfails else self.expected)
+            failures.sort(key=lambda f: f.get('file', ''))
+            json.dump([{key: value for key, value in failure.items() if not key.startswith('_')} for failure in failures], json_out, indent=4)
+
+    def _is_expected_failure(self, failure):
+        return any(self._xfail_matches(failure, xfail) for xfail in self.xfails)
+
+    def _saw_matching_file(self, xfail_file):
+        if not xfail_file:
+            return True
+        return any(re.match(self._wildcard_to_regex(xfail_file), seen_file) for seen_file in self.seen_files)
+
+    @classmethod
+    def _xfail_matches(cls, failure, xfail):
+      for key, value in xfail.items():
+        if key in ['issue', 'branches', '_matched']:
+          continue
+        if key in failure and re.match(cls._wildcard_to_regex(str(value)), str(failure[key])):
+          continue
+        return False
+
+      xfail['_matched'] = True
+      if 'issue' in xfail:
+        failure['issue'] = xfail['issue']
+      return True
+
+    @staticmethod
+    def _load_applicable_xfails(xfails_path, swift_branch):
+        with open(xfails_path) as json_file:
+            return [xfail for xfail in json.load(json_file) if swift_branch in xfail['branches']]
+
+    @staticmethod
+    def _wildcard_to_regex(wildcard_string):
+      regex_parts = [re.escape(item) for item in wildcard_string.split('*')]
+      return r'.*'.join(regex_parts) + r'$'
+
+
+class StressTesterRunner(object):
+    """sets up the Swift compatibility suite runner to use the stress tester's swiftc-wrapper, executes it, and processes its output for failures."""
+
+    def __init__(self, wrapper, stress_tester, swiftc, failure_manager):
+        self.wrapper = wrapper
+        self.stress_tester = stress_tester
+        self.swiftc = swiftc
+
+        self.failure_manager = failure_manager
+        self.compat_runner_failed = False
+
+    def run(self, projects_json, swift_branch, extra_runner_args=[]):
+        run_env = {
+            'SK_STRESS_TEST': self.stress_tester,
+            'SK_STRESS_SWIFTC': self.swiftc,
+            'SK_STRESS_SILENT': '',
+            'SK_STRESS_CODECOMPLETE_LIMIT': '1000' }
+        run_env.update(os.environ)
+        filtered_projects_json = self._rewrite_projects_json(projects_json, os.path.join(script_dir, 'stress-tester-projects.json'))
+
+        run_cmd = ['python', '-u', 'runner.py',
+          '--projects', filtered_projects_json,
+          '--verbose',
+          '--swiftc', self.wrapper,
+          '--swift-branch', swift_branch,
+          '--default-timeout', str(180*60),
+          '--only-latest-versions',
+          # archs overrie is set to arm64 for generic/iOS actions that would otherwise invoke the stress tester for both arm64 and armv7
+          '--add-xcodebuild-flags', 'ARCHS={archs_override}']
+
+        if extra_runner_args:
+            run_cmd.extend(extra_runner_args)
+
+        try:
+            for line in check_output_lines(run_cmd, env=run_env):
+                self._process_line(line)
+        except subprocess.CalledProcessError:
+            self.compat_runner_failed = True
+
+        self._print_summary(swift_branch)
+        return self._succeeded
+
+    @property
+    def _succeeded(self):
+        return not self.compat_runner_failed and (len(self.failure_manager.unexpected) == len(self.failure_manager.unmatched_xfails) == 0)
+
+    def _process_line(self, line):
+        (kind, failure) = self.failure_manager.process_line(line)
+        if kind == FailureKind.XFAIL:
+            print('[XFAIL][{}]{}'.format(failure['issue'] if 'issue' in failure else '<missing issue>', line))
+            return
+        print(line)
+        if kind == FailureKind.FAIL:
+            self._print_failure_instructions(failure)
+
+    def _print_failure_instructions(self, failure):
+        example = {'issue': '<issue url>'}
+
+        file_parts = failure['file'].split('/')
+        example['file'] = file_parts[0] + '/*' if len(file_parts) > 1 else '*'
+        project_json = json.dumps(example, indent=2)
+
+        example['file'] = failure['file']
+        file_json = json.dumps(example, indent=2)
+
+        example.update(failure)
+        exact_json = json.dumps(example, indent=2)
+
+        xfails_path = self.failure_manager.xfails_path        
+        path_text = ':\n  {}'.format(xfails_path) if xfails_path else '.'
+
+        print('''
+** STRESS TESTER FAILURE **
+
+Please file an issue against SourceKit with the '[sk-stress-test] error:'
+line above and add an expected failure to the JSON file passed via the
+--xfail-json option{path}
+
+To mark this specific failure as expected, include the below:
+{exact}
+
+To mark all failures in the same file as expected, include:
+{file}
+
+Or to mark all failures in a directory as expected, use a wildcard:
+{project}
+'''.format(path=path_text, exact=exact_json, file=file_json, project=project_json))
+
+    def _print_summary(self, swift_branch):
+        num_failures = len(self.failure_manager.unexpected)
+        num_xfails = len(self.failure_manager.expected)
+        unmatched = self.failure_manager.unmatched_xfails
+        xfails_path = self.failure_manager.xfails_path
+        unrecognized_errors = self.failure_manager.unrecognized_errors
+
+        print('SourceKit Stress Tester summary:')
+        
+        print('  {} underlying source compatibility build'.format('failed' if self.compat_runner_failed else 'passed'))
+        if self.compat_runner_failed:
+            print('      > treat this as a source compatibility failure')
+        
+        print('  {} unexpected stress tester failures'.format(num_failures))
+        if num_failures > 0:
+            print('      > search "** STRESS TESTER FAILURE **" for individual failures and filing instructions')
+
+        print('  {} expected stress tester failures'.format(num_xfails))
+
+        if not self.compat_runner_failed and unmatched:
+            print('  {} expected stress tester failures not seen'.format(len(unmatched)))
+            print('      > if resolved, remove "{}" from "branches" in the following entries in {} or the entire entry if no branches remain:'.format(swift_branch, xfails_path))
+            for xfail in unmatched:
+                print('      {}'.format(json.dumps(xfail)))
+
+        if unrecognized_errors:
+            print('  {} unrecognised stress tester errors (warning)'.format(len(unrecognized_errors)))
+            print('      > the SourceKit stress tester reported errors this script doesn\'t yet recognize')
+
+        print('========================================')
+        print('Result: {result}'.format(result=('PASS' if self._succeeded else 'FAIL')))
+        print('========================================')
+
+
+    @staticmethod
+    def _rewrite_projects_json(current, output):
+        with open(current) as json_file:
+            projects = json.load(json_file)
+            for project in projects:
+                for action in project['actions']:
+                    # This is used in combination with --add-xcodebuild-flags to prevent running the stress tester over the same files twice.
+                    # generic/iOS actions invoke the wrapper for both arm64 and armv7, which makes little difference for the stress tester.
+                    action['archs_override'] = 'arm64' if action.get('destination') == 'generic/platform=iOS' else '$ARCHS'
+
+        with open(output, 'w') as outfile:
+            json.dump(projects, outfile, indent=4)
+        return output
+
+def check_output_lines(cmd, env=None):
+    """a generator yielding each line the given command writes to stdout and stderr as it appears."""
+    common.shell_debug_print(cmd)
+
+    p = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
+    for line in iter(p.stdout.readline, ''):
+        yield line.rstrip()
+    p.stdout.close()
+
+    return_code = p.poll()
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, cmd)
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/runner.py
+++ b/runner.py
@@ -26,12 +26,17 @@ def parse_args():
     parser = argparse.ArgumentParser()
     project_future.add_arguments(parser)
     parser.add_argument('--only-latest-versions', action='store_true')
+    parser.add_argument('--default-timeout', type=int, help="override the default execute timeout (seconds)")
     return parser.parse_args()
 
 
 def main():
     """Execute specified indexed project actions."""
     args = parse_args()
+
+    if args.default_timeout:
+        common.set_default_execute_timeout(args.default_timeout)
+
     index = json.loads(open(args.projects).read())
     result = project_future.ProjectListBuilder(
         args.include_repos,

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1,0 +1,1124 @@
+[
+  {
+    "branches": ["master"],
+    "file": "AMScrollingNavbar/Source/ScrollingNavbar+Sizes.swift",
+    "offset": 191,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "file": "Alamofire/Source/AFError.swift",
+    "offset": 8221,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "file": "Alamofire/Source/Alamofire.swift",
+    "offset": 3719,
+    "length": 9,
+    "request": "RangeInfo",
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "AsyncNinja/Sources/BaseProducer.swift",
+    "offset": 1146,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "AsyncNinja/Sources/BaseProducer.swift",
+    "offset": 1773,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "BlueSocket/Sources/Socket.swift",
+    "offset": 10012,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "BlueSocket/Sources/Socket.swift",
+    "offset": 30861,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Chatto/Chatto/Source/Chat Items/BaseChatItemPresenter.swift",
+    "offset": 2550,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "Chatto/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageModel.swift",
+    "offset": 1128,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 12,
+    "file": "Chatto/Chatto/Source/Chat Items/ChatItemCompanion.swift",
+    "offset": 1580,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 34,
+    "file": "Chatto/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift",
+    "offset": 8369,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "CleanroomLogger/Sources/BasicLogConfiguration.swift",
+    "offset": 3132,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 8,
+    "file": "CleanroomLogger/Sources/ConcatenatingLogFormatter.swift",
+    "offset": 2348,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "CoreStore/Sources/AsynchronousDataTransaction.swift",
+    "offset": 2119,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 22,
+    "file": "CoreStore/Sources/CSDataStack+Observing.swift",
+    "offset": 3048,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 13,
+    "file": "cub/Sources/Cub/AST/Nodes/ArrayNode.swift",
+    "offset": 758,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "cub/Sources/Cub/AST/ASTNode+Validation.swift",
+    "offset": 198,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "request": "CursorInfo",
+    "failure": "crashed",
+    "file": "DNS/Sources/DNS/Bytes.swift",
+    "offset": 2565,
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 16,
+    "file": "DNS/Sources/DNS/Bytes.swift",
+    "offset": 6663,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 24,
+    "file": "Deferred/Sources/Deferred/Deferred.swift",
+    "offset": 2331,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Deferred/Sources/Task/TaskAndThen.swift",
+    "offset": 2614,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Dollar/Sources/Dollar.swift",
+    "offset": 5214,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "Dwifft/Dwifft/Dwifft+UIKit.swift",
+    "offset": 1541,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/submodules/RSCore/RSCore/AppKit/LogWindowController.swift",
+    "offset": 167,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 18,
+    "file": "Evergreen/submodules/RSCore/RSCore/RSToolbarItem.swift",
+    "offset": 1174,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "Evergreen/submodules/RSParser/Sources/Feeds/FeedType.swift",
+    "offset": 705,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 17,
+    "file": "Evergreen/submodules/RSDatabase/RSDatabase/DatabaseObject.swift",
+    "offset": 649,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 24,
+    "file": "Evergreen/submodules/RSWeb/RSWeb/DownloadSession.swift",
+    "offset": 3145,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/submodules/RSDatabase/RSDatabase/DatabaseTable.swift",
+    "offset": 2528,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/submodules/RSTree/RSTree/NSOutlineView+RSTree.swift",
+    "offset": 166,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/submodules/RSWeb/RSWeb/Credentials.swift",
+    "offset": 152,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Evergreen/Frameworks/Data/DatabaseID.swift",
+    "offset": 488,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/Frameworks/Data/Article.swift",
+    "offset": 151,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/Frameworks/Database/ArticlesTable.swift",
+    "offset": 162,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "Evergreen/Frameworks/Account/Account.swift",
+    "offset": 4496,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/Frameworks/Account/Account.swift",
+    "offset": 156,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "file": "Evergreen/AppleEvents/AppleEventUtils.swift",
+    "offset": 158,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 24,
+    "file": "Evergreen/Frameworks/Account/Account.swift",
+    "offset": 2653,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 20,
+    "file": "Evergreen/Commands/DeleteFromSidebarCommand.swift",
+    "offset": 2831,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "request": "SemanticRefactoring",
+    "refactoring": "Convert To Trailing Closure",
+    "file": "exercism-*swift/exercises/word-count/Sources/WordCountExample.swift",
+    "offset": 97,
+    "issue": "https://github.com/apple/swift/pull/17291 (fixed on master; rdar://problem/41093898)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "exercism-*swift/exercises/acronym/Sources/AcronymExample.swift",
+    "offset": 913,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "fluent/Sources/Fluent/Cache/CacheEntry.swift",
+    "offset": 534,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8042"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "fluent/Sources/FluentBenchmark/Benchmarks/Bar.swift",
+    "offset": 240,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8042"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "GRDB.swift/GRDB/Core/Cursor.swift",
+    "offset": 22555,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallBeat.swift",
+    "offset": 2007,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallPulseRise.swift",
+    "offset": 2460,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18665 (fixed on master; rdar://problem/42639255)"
+  },
+  {
+    "branches": ["master"],
+    "file": "JSQCoreDataKit/Source/CoreDataEntityProtocol.swift",
+    "offset": 853,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "file": "JSQDataSourcesKit/Source/BridgedDataSource.swift",
+    "offset": 3924,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "JSQDataSourcesKit/Source/ReusableViewConfig.swift",
+    "offset": 6930,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/commit/398abdfb (fixed on master; rdar://problem/41175473)"
+  },
+  {
+    "branches": ["master"],
+    "file": "KeychainAccess/Lib/KeychainAccess/Keychain.swift",
+    "offset": 8251,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 26,
+    "file": "KeychainAccess/Lib/KeychainAccess/Keychain.swift",
+    "offset": 18237,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "request": "CursorInfo",
+    "failure": "crashed",
+    "file": "Kickstarter-Prelude/Prelude/Array.swift",
+    "offset": 2127,
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Kickstarter-Prelude/Prelude/Optional.swift",
+    "offset": 1585,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/17339 (fixed on master; rdar://problem/41219750)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "Kickstarter-Prelude/Prelude-UIKit/UIButton.swift",
+    "offset": 339,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Kickstarter-Prelude/Prelude-UIKit/UIImage.swift",
+    "offset": 309,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Kickstarter-ReactiveExtensions/Frameworks/ReactiveSwift/Sources/Action.swift",
+    "offset": 3959,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Kingfisher/Sources/Box.swift",
+    "offset": 1223,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Kingfisher/Sources/Image.swift",
+    "offset": 21272,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "failed",
+    "request": "SemanticRefactoring",
+    "refactoring": "Local Rename",
+    "file": "Kitura/Sources/Kitura/CodableRouter.swift",
+    "offset": 45420,
+    "issue": "https://bugs.swift.org/browse/SR-8566"
+  },
+  {
+    "branches": ["master"],
+    "request": "CursorInfo",
+    "failure": "crashed",
+    "file": "Kitura/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift",
+    "offset": 2343,
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["master"],
+    "file": "Kronos/Sources/Clock.swift",
+    "offset": 2593,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Kronos/Sources/DNSResolver.swift",
+    "offset": 3012,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 16,
+    "file": "Lark/Sources/Lark/Client.swift",
+    "offset": 6608,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 9,
+    "file": "Lark/Sources/CodeGenerator/Generator.swift",
+    "offset": 5239,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 16,
+    "file": "Moya/Sources/Moya/AnyEncodable.swift",
+    "offset": 233,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Moya/Sources/ReactiveMoya/MoyaProvider+Reactive.swift",
+    "offset": 382,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Moya/Sources/RxMoya/MoyaProvider+Rx.swift",
+    "offset": 1536,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "NetService/Sources/NetService/Compat.swift",
+    "offset": 77,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18354 (fixed on master; rdar://problem/41217187)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "SemanticRefactoring",
+    "failure": "crashed",
+    "refactoring": "Convert To Trailing Closure",
+    "file": "launchscreensnapshot/LaunchScreenSnapshot/LaunchScreenSnapshot.swift",
+    "offset": 8942,
+    "issue": "https://github.com/apple/swift/pull/17291 (fixed on master; rdar://problem/41093898)"
+  },
+  {
+    "branches": ["master"],
+    "file": "ObjectMapper/Sources/CustomDateFormatTransform.swift",
+    "offset": 1264,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "ObjectMapper/Sources/DictionaryTransform.swift",
+    "offset": 626,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8565"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Perfect/Sources/PerfectLib/Dir.swift",
+    "offset": 2466,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "PinkyPromise/Sources/Promise.swift",
+    "offset": 11022,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 11,
+    "file": "Plank/Sources/Core/FileGenerator.swift",
+    "offset": 1744,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "ProcedureKit/Sources/ProcedureKit/Any.swift",
+    "offset": 1387,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 11,
+    "file": "ProcedureKit/Sources/ProcedureKit/Any.swift",
+    "offset": 3649,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 11,
+    "file": "ProcedureKit/Sources/ProcedureKitCloud/CloudKit.swift",
+    "offset": 554,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "ProcedureKit/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift",
+    "offset": 1217,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "PromiseKit/Sources/AnyPromise.swift",
+    "offset": 5184,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "PromiseKit/Sources/AnyPromise.swift",
+    "offset": 5252,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/18354 (fixed on master; rdar://problem/41217187)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 19,
+    "file": "R.swift/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift",
+    "offset": 675,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "CursorInfo",
+    "failure": "crashed",
+    "file": "Re-Lax/ReLax/ReLax/DataHelpers.swift",
+    "offset": 145,
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "Re-Lax/ReLax/ReLax/LCRFlattenedRendition.swift",
+    "offset": 1537,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["master"],
+    "file": "ReSwift/ReSwift/CoreTypes/Action.swift",
+    "offset": 2037,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "ReactiveCocoa/ReactiveCocoa/NSObject+Association.swift",
+    "offset": 3699,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8397"
+  },
+  {
+    "failure": "crashed",
+    "branches": ["master"],
+    "file": "ReactiveCocoa/ReactiveCocoa/AppKit/ActionProxy.swift",
+    "offset": 7,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "ReactiveSwift/Sources/Action.swift",
+    "offset": 4431,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "ReactiveSwift/Sources/Action.swift",
+    "offset": 5419,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+{
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 26,
+    "file": "Result/Result/Result.swift",
+    "offset": 7559,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "RxSwift/RxSwift/Concurrency/AsyncLock.swift",
+    "offset": 1036,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "RxSwift/Platform/DispatchQueue+Extensions.swift",
+    "offset": 329,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 18,
+    "file": "RxSwift/RxCocoa/Common/Binder.swift",
+    "offset": 1147,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "RxSwift/RxCocoa/Common/Binder.swift",
+    "offset": 149,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "file": "RxSwift/RxBlocking/BlockingObservable+Operators.swift",
+    "offset": 3131,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "RxSwift/RxBlocking/BlockingObservable+Operators.swift",
+    "offset": 4157,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "RxSwift/RxTest/Any+Equatable.swift",
+    "offset": 296,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "RxSwift/RxTest/Platform/DeprecationWarner.swift",
+    "offset": 678,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8474"
+  },
+  {
+    "branches": ["master"],
+    "file": "SRP/Sources/AuthenticationFailure.swift",
+    "offset": 700,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 29,
+    "file": "Serpent/Sources/BridgingBox.swift",
+    "offset": 1015,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "Sourcery/Sources/SourceryRuntime/Diffable.swift",
+    "offset": 3072,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Starscream/Sources/SSLSecurity.swift",
+    "offset": 2600,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8556"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 15,
+    "file": "Starscream/Sources/WebSocket.swift",
+    "offset": 26364,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "Surge/Source/Matrix.swift",
+    "offset": 3657,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "SwiftDate/Sources/DateRepresentable.swift",
+    "offset": 11081,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 12,
+    "file": "SwiftDate/Sources/DateRepresentable.swift",
+    "offset": 17648,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "request": "CursorInfo",
+    "failure": "crashed",
+    "file": "SwiftGraph/Sources/SwiftGraph/Cycle.swift",
+    "offset": 1388,
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 14,
+    "file": "SwiftGraph/Sources/SwiftGraph/Cycle.swift",
+    "offset": 3256,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "SwiftLint/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift",
+    "offset": 797,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 26,
+    "file": "SwiftLint/Source/swiftlint/Commands/GenerateDocsCommand.swift",
+    "offset": 702,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "SwifterSwift/Sources/Extensions/AppKit/NSImageExtensions.swift",
+    "offset": 138,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOConcurrencyHelpers/atomics.swift",
+    "offset": 15907,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8554"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOPriorityQueue/Heap.swift",
+    "offset": 4260,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOConcurrencyHelpers/lock.swift",
+    "offset": 2633,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIO/BaseSocket.swift",
+    "offset": 1226,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIO/BaseSocket.swift",
+    "offset": 13934,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOEchoServer/main.swift",
+    "offset": 2692,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOChatClient/main.swift",
+    "offset": 1522,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOEchoClient/main.swift",
+    "offset": 2200,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOChatServer/main.swift",
+    "offset": 6295,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOChatClient/main.swift",
+    "offset": 815,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift",
+    "offset": 4172,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOChatServer/main.swift",
+    "offset": 1051,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift",
+    "offset": 4010,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOHTTP1/HTTPDecoder.swift",
+    "offset": 2212,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOHTTP1/HTTPDecoder.swift",
+    "offset": 8123,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOHTTP1Server/main.swift",
+    "offset": 7812,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOWebSocket/Base64.swift",
+    "offset": 1773,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOPerformanceTester/main.swift",
+    "offset": 2824,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "swift-nio/Sources/NIOWebSocketServer/main.swift",
+    "offset": 2037,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOHTTP1Server/main.swift",
+    "offset": 23695,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOPerformanceTester/main.swift",
+    "offset": 4028,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "swift-nio/Sources/NIOWebSocketServer/main.swift",
+    "offset": 8969,
+    "request": "CursorInfo",
+    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
+  },
+  {
+    "branches": ["master"],
+    "file": "kommander/Source/CurrentDispatcher.swift",
+    "offset": 416,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "launchscreensnapshot/LaunchScreenSnapshot/LaunchScreenSnapshot.swift",
+    "offset": 7191,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["master"],
+    "file": "mapper/Sources/DefaultConvertible.swift",
+    "offset": 754,
+    "request": "CodeComplete",
+    "issue": "https://bugs.swift.org/browse/SR-8555"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 30,
+    "file": "SwiftyStoreKit/SwiftyStoreKit/CompleteTransactionsController.swift",
+    "offset": 2818,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "URBNJSONDecodableSPM/Sources/JSONDecodable.swift",
+    "offset": 3635,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/commit/398abdfb (fixed on master; rdar://problem/41175473)"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "failed",
+    "request": "SemanticRefactoring",
+    "refactoring": "Local Rename",
+    "file": "mapper/Sources/Mapper.swift",
+    "offset": 1650,
+    "issue": "https://bugs.swift.org/browse/SR-8566"
+  },
+  {
+    "branches": ["master"],
+    "failure": "crashed",
+    "file": "panelkit/PanelKit/Controller/PanelNavigationController.swift",
+    "offset": 629,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8559"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "request": "RangeInfo",
+    "failure": "crashed",
+    "length": 24,
+    "file": "panelkit/PanelKit/Controller/PanelViewController+Dragging.swift",
+    "offset": 379,
+    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
+  },
+  {
+    "branches": ["master"],
+    "file": "siesta/Source/Siesta/Configuration.swift",
+    "offset": 148,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8553"
+  },
+  {
+    "branches": ["swift-4.2-branch"],
+    "failure": "crashed",
+    "file": "siesta/Source/Siesta/Entity.swift",
+    "offset": 7210,
+    "request": "CodeComplete",
+    "issue": "https://github.com/apple/swift/pull/17339 (fixed on master; rdar://problem/41219750)"
+  }
+]


### PR DESCRIPTION
The run_sk_stress_test script invokes runner.py passing sk-swiftc-wrapper to `--swiftc`. This wrapper invokes swiftc, forwarding its own arguments on to it. If the swiftc invocation succeeds it them invokes sk-stress-test, which stress tests SourceKit on all the .swift files in the passed compiler arguments.

As invoking swiftc and the stress tester takes significantly longer than swiftc alone, the script tries to bring down the runtime without sacrificing too much coverage by:

1. only running over the latest swift compatibilty version supported by each repo
2. only running over one of each set of platform-specific actions/schemes (e.g. just RxSwift-macOS, rather than that + RxSwift-iOs, RxSift-tvOS, etc.)
3. only building generic/iOS actions for arm64, rather than arm64 and armv7

This patch also adds:
- an addition option to override the default timeout for `common.check_execute()` and related helper methods, as it was hitting the hard-coded default
- an optional 'tags' field on some actions that's used in combination with `--include-acions` to select the subset of actions to use in both a 'full' stress tester run (tagged with 'sourcekit'), and the further reduced set intended for PR testing (tagged with 'sourcekit-smoke')