### PR TITLE
Update project_precommit_check 4.2 config to Xcode 10 beta 6

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -68,9 +68,9 @@ supported_configs = {
         },
         '4.2': {
             'version': 'Apple Swift version 4.2 '
-                       '(swiftlang-1000.0.32.1 clang-1000.10.39)\n'
+                       '(swiftlang-1000.0.36 clang-1000.10.44)\n'
                        'Target: x86_64-apple-darwin17.7.0\n',
-            'description': 'Xcode 10 Beta 5 (contains Swift 4.2)',
+            'description': 'Xcode 10 Beta 6 (contains Swift 4.2)',
             'branch': 'swift-4.2-branch'
         }
     },


### PR DESCRIPTION
### Pull Request Description
Update project_precommit_check's 4.2 config to the swiftlang version that ships in Xcode 10 beta 6.

```
$ swift -version
Apple Swift version 4.2 (swiftlang-1000.0.36 clang-1000.10.44)
Target: x86_64-apple-darwin18.0.0
```