### PR TITLE
Update PinkyPromise hash to 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1379,8 +1379,8 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "a127ac74685daec77dd4580bd82c8ace8cc9cc29"
+        "version": "4.2",
+        "commit": "5c15634de4ff3152e9ccede6543c83ed93e2cf7b"
       }
     ],
     "platforms": [
@@ -1407,7 +1407,7 @@
         "configuration": "release",
         "xfail": {
           "compatibility": {
-            "3.0": {
+            "4.2": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-8250"
               }


### PR DESCRIPTION
### Pull Request Description

The xfail for https://bugs.swift.org/browse/SR-8250 is still valid, and is bumped to 4.2 along with the BuildSwiftPackage configuration.

- [x] pass `./project_precommit_check` script run
```
./project_precommit_check PinkyPromise --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating PinkyPromise Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking PinkyPromise platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "PinkyPromise"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: PinkyPromise, 4.2, 5c1563, PinkyPromise_iOS, generic/platform=iOS
PASS: PinkyPromise, 4.2, 5c1563, PinkyPromise_macOS, generic/platform=macOS
PASS: PinkyPromise, 4.2, 5c1563, Swift Package
========================================
Action Summary:
     Passed: 3
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 3
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```

Ensure project meets all listed requirements before submitting a pull request.