### PR TITLE
Update Serpent hash to 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2020,24 +2020,24 @@
     "url": "https://github.com/nodes-ios/Serpent.git",
     "path": "Serpent",
     "branch": "master",
+    "maintainer": "ios@nodes.dk",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "16a3bf87f4b3ad13827c65deabb0bf0af07ae59d"
+        "version": "4.2",
+        "commit": "33ce18293ef42e5565ce285a15ee70ac9d5b121d"
       }
     ],
     "platforms": [
       "Darwin",
       "Linux"
     ],
-    "maintainer": "ios@nodes.dk",
     "actions": [
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "xfail": {
           "compatibility": {
-            "3.0": {
+            "4.2": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-8250"
               }


### PR DESCRIPTION
### Pull Request Description

The xfail for https://bugs.swift.org/browse/SR-8250 is still valid, and is bumped to 4.2 along with the BuildSwiftPackage configuration.

- [x] pass `./project_precommit_check` script run
```
./project_precommit_check Serpent --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating Serpent Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking Serpent platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "Serpent"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: Serpent, 4.2, 33ce18, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Serpent checked successfully against Swift 4.2 ---
```