### PR TITLE
Update Then hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2449,16 +2449,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "3.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8250"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -2438,8 +2438,8 @@
     "maintainer": "devxoul@gmail.com",
     "compatibility": [
       {
-        "version": "3.1",
-        "commit": "daaea1ac2100ae86bd20f0920ebbd2f1becb2e6e"
+        "version": "4.2",
+        "commit": "3edb1c0f557506d845362fda6d8564718435bfb1"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

Updates the hash to a recent commit, and also updates the configuration to build against Swift 4.2. Also removes the xfail from https://bugs.swift.org/browse/SR-8250.

### Acceptance Criteria

- [x] pass `./project_precommit_check` script run
```
./project_precommit_check Then --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating Then Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking Then platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "Then"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: Then, 4.2, 3edb1c, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Then checked successfully against Swift 4.2 ---
```
Ensure project meets all listed requirements before submitting a pull request.