### PR TITLE
Update GRDB.swift hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -731,7 +731,7 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "0e0ebdb2d65f4c313f7e70c0fdf8d5e805aaa4aa"
+        "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -730,8 +730,8 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "f121c6b1393aacf6d1956ea9edf0dd1e9c34977f"
+        "version": "4.2",
+        "commit": "0e0ebdb2d65f4c313f7e70c0fdf8d5e805aaa4aa"
       }
     ],
     "platforms": [
@@ -742,16 +742,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -742,6 +742,15 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9151"
+              }
+            }
+          }
+        },
         "tags": "sourcekit"
       },
       {


### PR DESCRIPTION
### Pull Request Description

Updates the hash to a recent commit, and also updates the configuration to build against Swift 4.2. Also removes the xfail from https://bugs.swift.org/browse/SR-8234. 

### Acceptance Criteria
- [x] pass `./project_precommit_check` script run
```
./project_precommit_check GRDB.swift --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating GRDB.swift Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking GRDB.swift platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode_10_Beta_6.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "GRDB.swift"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: GRDB.swift, 4.2, 0e0ebd, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- GRDB.swift checked successfully against Swift 4.2 ---
```