### PR TITLE
Update Perfect hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1363,8 +1363,8 @@
     "maintainer": "sean@perfect.org",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "540feb1d8b3c1965823e0e3ecc9e975d47006b80"
+        "version": "4.2",
+        "commit": "cdc17d544ec8e87da5f3b24cdbda8d02d77bb943"
       }
     ],
     "platforms": [
@@ -1375,16 +1375,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

Updates the hash to be built against Swift 4.2. Also removes the xfail from the 4.0 configuration, because of [SR-8234](https://bugs.swift.org/browse/SR-8234).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] pass `./project_precommit_check` script run
```
PASS: Perfect, 4.2, cdc17d, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```