### PR TITLE
Update Plank hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1458,8 +1458,8 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "fe78418de7757d100c94f702e8effb5e7b8e93b8"
+        "version": "4.2",
+        "commit": "71a3a5ce5e38161eaf4e46a7f609f2e4523d8248"
       }
     ],
     "maintainer": "rmalik@pinterest.com",
@@ -1471,16 +1471,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

Updates the hash to be built against Swift 4.2. Also removes the xfail from the 4.0 configuration, because of [SR-8234](https://bugs.swift.org/browse/SR-8234).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] pass `./project_precommit_check` script run
```
PASS: Plank, 4.2, 71a3a5, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```