### PR TITLE
Update R.swift hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1613,8 +1613,8 @@
     "maintainer": "tom@lokhorst.eu",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "c5273e456ef02230689f6db2172abb29901115f0"
+        "version": "4.2",
+        "commit": "f96758593573d3d1d9ae8084721033ab0bf392f6"
       }
     ],
     "platforms": [
@@ -1624,16 +1624,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

Updates the hash to be built against Swift 4.2. Also removes the xfail from the 4.0 configuration, because of [SR-8234](https://bugs.swift.org/browse/SR-8234).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] pass `./project_precommit_check` script run
```
PASS: R.swift, 4.2, f96758, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```