### PR TITLE
Update Result hash to build against 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1815,8 +1815,8 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "7477584259bfce2560a19e06ad9f71db441fff11"
+        "version": "4.2",
+        "commit": "2fe5b325a8a54e77c545b2f511213420da133b8c"
       }
     ],
     "maintainer": "matt@diephouse.com",
@@ -1828,16 +1828,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

Updates the hash to be built against Swift 4.2. Also removes the xfail from the 4.0 configuration, because of [SR-8234](https://bugs.swift.org/browse/SR-8234).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] pass `./project_precommit_check` script run
```
PASS: Result, 4.2, 2fe5b3, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```