### PR TITLE
Fix Mapper SwiftPM compatibility

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2564,10 +2564,6 @@
         "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
       },
       {
-        "version": "4.1",
-        "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
-      },
-      {
         "version": "4.2",
         "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
       }

--- a/projects.json
+++ b/projects.json
@@ -2561,7 +2561,15 @@
     "compatibility": [
       {
         "version": "4.0",
-        "commit": "45f5726304f41e6e6ad5d3d836e89940e165f48d"
+        "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
+      },
+      {
+        "version": "4.1",
+        "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
+      },
+      {
+        "version": "4.2",
+        "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
       }
     ],
     "platforms": [
@@ -2599,16 +2607,7 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8250"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
Previously Mapper used a Swift 3 style Package.swift. Now on master this
has been updated to be a 4.2 format manifest, that supports building 4.0

I'm not sure if this format is correct, I updated the sha for 4.0, and added 4.1, but with the current Mapper configuration these still have to be built with the 4.2 compiler, just in 4.0 mode.