### PR TITLE
Only build watchOS project for armv7k <rdar://problem/44522408>

### DIFF
--- a/project.py
+++ b/project.py
@@ -124,6 +124,8 @@ class XcodeTarget(ProjectTarget):
                 command += ['-configuration', value]
             else:
                 command += ['%s=%s' % (setting, value)]
+        if self._destination == 'generic/platform=watchOS':
+            command += ['ARCHS=armv7k']
 
         return command
 

--- a/project_future.py
+++ b/project_future.py
@@ -124,6 +124,9 @@ class XcodeTarget(ProjectTarget):
                       'SWIFT_TREAT_WARNINGS_AS_ERRORS=NO'])
         command += self._added_xcodebuild_flags
 
+        if self._destination == 'generic/platform=watchOS':
+            command += ['ARCHS=armv7k']
+
         return command
 
     def get_test_command(self, incremental=False):

--- a/projects.json
+++ b/projects.json
@@ -2617,7 +2617,23 @@
         "project": "Mapper.xcodeproj",
         "target": "Mapper",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8778",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8778"
+              }
+            },
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8778",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8778"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildSwiftPackage",

--- a/projects.json
+++ b/projects.json
@@ -1581,7 +1581,17 @@
         "project": "PromiseKit.xcodeproj",
         "target": "PromiseKit",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.0.3": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8781",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8781"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",

--- a/projects.json
+++ b/projects.json
@@ -1500,7 +1500,17 @@
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "3.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8780",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-8780"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",


### PR DESCRIPTION
Verified locally: 

```
PASS: AMScrollingNavbar, 4.0, de70ea, AMScrollingNavbar, generic/platform=iOS
PASS: Alamofire, 3.0, b03b43, Alamofire iOS, generic/platform=iOS
PASS: Alamofire, 3.0, b03b43, Alamofire macOS, generic/platform=macOS
PASS: Alamofire, 3.0, b03b43, Alamofire tvOS, generic/platform=tvOS
PASS: Alamofire, 3.0, b03b43, Alamofire watchOS, generic/platform=watchOS
PASS: Alamofire, 3.0, b03b43, iOS Example, generic/platform=iOS
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=macOS
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=iOS
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=tvOS
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=watchOS
PASS: AsyncNinja, 4.0, efc83b, Swift Package
UPASS: https://bugs.swift.org/browse/SR-8234, BeaconKit, 4.0, 189b40, Swift Package
PASS: BlueSocket, 3.0, b0dcf1, Socket, generic/platform=macOS
PASS: BlueSocket, 3.0, b0dcf1, Socket-iOS, generic/platform=iOS
PASS: Chatto, 4.0.3, 3e4b1a, Chatto, generic/platform=iOS
PASS: Chatto, 4.0.3, 3e4b1a, ChattoAdditions, generic/platform=iOS
PASS: Chatto, 4.0.3, 3e4b1a, ChattoApp, generic/platform=iOS
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=iOS
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=macOS
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=tvOS
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=watchOS
PASS: CoreStore, 4.0, 83e608, CoreStore iOS, generic/platform=iOS
PASS: CoreStore, 4.0, 83e608, CoreStore OSX, generic/platform=macOS
PASS: CoreStore, 4.0, 83e608, CoreStore tvOS, generic/platform=tvOS
PASS: CoreStore, 4.0, 83e608, CoreStore watchOS, generic/platform=watchOS
PASS: CoreStore, 4.0, 83e608, CoreStoreDemo, generic/platform=iOS
PASS: cub, 4.0.3, 3574d3, Cub iOS [Double], generic/platform=iOS
PASS: cub, 4.0.3, 3574d3, Cub macOS Release [Double], generic/platform=macOS
PASS: DNS, 4.0, 04ae84, Swift Package
PASS: Deferred, 4.2, c374a6, Swift Package
PASS: Deferred, 4.2, c374a6, MobileDeferred, generic/platform=iOS
PASS: Deferred, 4.2, c374a6, TVDeferred, generic/platform=tvOS
PASS: Deferred, 4.2, c374a6, NanoDeferred, generic/platform=watchOS
PASS: Dollar, 4.0, 433d4b, Dollar, generic/platform=macOS
PASS: Dwifft, 4.0, 6e09d2, Dwifft, generic/platform=iOS
PASS: Evergreen, 4.2, ce0d24, Evergreen, generic/platform=macOS
UPASS: https://bugs.swift.org/browse/SR-8307, exercism-swift, 4.2, 38a17d, Swift Package
```