### PR TITLE
Update swiftlang version to check against Xcode 10.0's

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -68,9 +68,9 @@ supported_configs = {
         },
         '4.2': {
             'version': 'Apple Swift version 4.2 '
-                       '(swiftlang-1000.0.36 clang-1000.10.44)\n'
+                       '(swiftlang-1000.11.37.1 clang-1000.11.45.1)\n'
                        'Target: x86_64-apple-darwin17.7.0\n',
-            'description': 'Xcode 10 Beta 6 (contains Swift 4.2)',
+            'description': 'Xcode 10.0 (contains Swift 4.2)',
             'branch': 'swift-4.2-branch'
         }
     },


### PR DESCRIPTION
### Pull Request Description

Update the swiftlang version in project_precommit_check to check against the version in Xcode 10.0.

- [x] pass `./project_precommit_check` script run
```
$ ./project_precommit_check Evergreen --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating Evergreen Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking Evergreen platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "Evergreen"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: Evergreen, 4.2, ce0d24, Evergreen, generic/platform=macOS
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Evergreen checked successfully against Swift 4.2 ---
```