### PR TITLE
Add swift-nonempty

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1321,7 +1321,16 @@
         "workspace": "NonEmpty.xcworkspace",
         "scheme": "NonEmpty-Package",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9068"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -1314,7 +1314,16 @@
         "workspace": "NonEmpty.xcworkspace",
         "scheme": "NonEmpty-Package",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9068"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -1307,7 +1307,16 @@
         "workspace": "NonEmpty.xcworkspace",
         "scheme": "NonEmpty-Package",
         "destination": "generic/platform=macOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9068"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -2912,5 +2912,59 @@
         "tags": "sourcekit"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/pointfreeco/swift-nonempty.git",
+    "path": "NonEmpty",
+    "branch": "master",
+    "maintainer": "support@pointfree.co",
+    "compatibility": [
+      {
+        "version": "4.1",
+        "commit": "1fe8684a8c2513bbc2388a464a871a434202edc2"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]

--- a/projects.json
+++ b/projects.json
@@ -1328,7 +1328,16 @@
         "workspace": "NonEmpty.xcworkspace",
         "scheme": "NonEmpty-Package",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9068"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildSwiftPackage",

--- a/projects.json
+++ b/projects.json
@@ -1287,6 +1287,60 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/pointfreeco/swift-nonempty.git",
+    "path": "NonEmpty",
+    "branch": "master",
+    "maintainer": "support@pointfree.co",
+    "compatibility": [
+      {
+        "version": "4.1",
+        "commit": "1fe8684a8c2513bbc2388a464a871a434202edc2"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "NonEmpty.xcworkspace",
+        "scheme": "NonEmpty-Package",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/Hearst-DD/ObjectMapper.git",
     "path": "ObjectMapper",
     "branch": "master",
@@ -2910,60 +2964,6 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "tags": "sourcekit"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/pointfreeco/swift-nonempty.git",
-    "path": "NonEmpty",
-    "branch": "master",
-    "maintainer": "support@pointfree.co",
-    "compatibility": [
-      {
-        "version": "4.1",
-        "commit": "1fe8684a8c2513bbc2388a464a871a434202edc2"
-      }
-    ],
-    "platforms": [
-      "Darwin",
-      "Linux"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "NonEmpty.xcworkspace",
-        "scheme": "NonEmpty-Package",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "NonEmpty.xcworkspace",
-        "scheme": "NonEmpty-Package",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "NonEmpty.xcworkspace",
-        "scheme": "NonEmpty-Package",
-        "destination": "generic/platform=tvOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "NonEmpty.xcworkspace",
-        "scheme": "NonEmpty-Package",
-        "destination": "generic/platform=watchOS",
-        "configuration": "Release"
-      },
-      {
-        "action": "BuildSwiftPackage",
-        "configuration": "release"
-      },
-      {
-        "action": "TestSwiftPackage"
       }
     ]
   }

--- a/projects.json
+++ b/projects.json
@@ -1332,7 +1332,16 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9068"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

This adds https://github.com/pointfreeco/swift-nonempty to the source compatibility suite. It is Swift 4.1-compatible and Swift 4.2 has introduced a regression: https://bugs.swift.org/browse/SR-8985

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project (both)
- [x] support building on either Linux or macOS (both)
- [x] target Linux, macOS, or iOS/tvOS/watchOS device (all of the above)
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift ~4.0~ 4.1 and passes any unit tests (this library relies on conditional conformance to be useful, requiring 4.1)
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm* (though it's technically not building on Linux due to a Swift 4.2 regression)
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT 👈
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run (TBD?)

Ensure project meets all listed requirements before submitting a pull request.

---

I've left one item unchecked since this library, relying heavily on conditional conformance, requires Swift 4.1. I hope the value proposition makes this worth inclusion regardless.