### PR TITLE
Xfail fluent and SwiftLint due to SR-9029

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -692,7 +692,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9029"
+              }
+            }
+          }
+        }
       }
     ]
   },
@@ -2273,7 +2282,21 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "4.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9029"
+              }
+            },
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9029"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

Adds xfail to fluent and SwiftLint due to https://bugs.swift.org/browse/SR-9029