### PR TITLE
Revert "Xfail fluent and SwiftLint due to SR-9029"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -692,16 +692,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9029"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       }
     ]
   },
@@ -2282,21 +2273,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9029"
-              }
-            },
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9029"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
This reverts commit 70ddb3726b8d69ba06c9f1f69dd9210184284035.

I fixed these in:

https://github.com/apple/swift/pull/19959
