### PR TITLE
Also xfail NonEmpty on swift-4.2-branch

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1359,7 +1359,8 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068"
+                "master": "https://bugs.swift.org/browse/SR-9068",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
               }
             }
           }
@@ -1375,7 +1376,8 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068"
+                "master": "https://bugs.swift.org/browse/SR-9068",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
               }
             }
           }
@@ -1391,7 +1393,8 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068"
+                "master": "https://bugs.swift.org/browse/SR-9068",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
               }
             }
           }
@@ -1407,7 +1410,8 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068"
+                "master": "https://bugs.swift.org/browse/SR-9068",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
               }
             }
           }
@@ -1420,7 +1424,8 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068"
+                "master": "https://bugs.swift.org/browse/SR-9068",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
               }
             }
           }


### PR DESCRIPTION
### Pull Request Description

Adds xfail to NonEmpty on swift-4.2-branch because it's hitting an assertion failure (see https://bugs.swift.org/browse/SR-9111).