### PR TITLE
Revert "Also xfail NonEmpty on swift-4.2-branch"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1359,8 +1359,7 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
+                "master": "https://bugs.swift.org/browse/SR-9068"
               }
             }
           }
@@ -1376,8 +1375,7 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
+                "master": "https://bugs.swift.org/browse/SR-9068"
               }
             }
           }
@@ -1393,8 +1391,7 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
+                "master": "https://bugs.swift.org/browse/SR-9068"
               }
             }
           }
@@ -1410,8 +1407,7 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
+                "master": "https://bugs.swift.org/browse/SR-9068"
               }
             }
           }
@@ -1424,8 +1420,7 @@
           "compatibility": {
             "4.1": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9068",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9111"
+                "master": "https://bugs.swift.org/browse/SR-9068"
               }
             }
           }


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#271