### PR TITLE
Drop Swift 3.0 configuration for JSQDataSourcesKit

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -868,10 +868,6 @@
       {
         "version": "4.0",
         "commit": "25ee7e2e2ab50d5e2237292ddc74973c68aee89a"
-      },
-      {
-        "version": "3.0",
-        "commit": "b764e341713d67ab9c8160929f46e55ad1e2ca07"
       }
     ],
     "platforms": [


### PR DESCRIPTION
This is done as part of the work for [SR-8174](https://bugs.swift.org/browse/SR-8174).