### PR TITLE
Update ProcedureKit to build against Swift 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1650,8 +1650,8 @@
     "maintainer": "danthorpe@me.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "d6389ea98ec2e0d17ab368f40045bfe48622ac67"
+        "version": "4.2",
+        "commit": "94193d59bc06689526772023428402da1e0e299f"
       }
     ],
     "platforms": [
@@ -1696,9 +1696,10 @@
         "tags": "sourcekit",
         "xfail": {
           "compatibility": {
-            "3.0": {
+            "4.2": {
               "branch": {
-                "swift-4.0-branch": "rdar://35814436"
+                "master": "https://bugs.swift.org/browse/SR-9139",
+                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9139"
               }
             }
           }


### PR DESCRIPTION
### Pull Request Description

Also add xfail of ProcedureKitCloud due to https://bugs.swift.org/browse/SR-9139

- [x] pass `./project_precommit_check` script run

```
$ ./project_precommit_check ProcedureKit --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating ProcedureKit Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking ProcedureKit platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/PublicGMs/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/PublicGMs/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "ProcedureKit"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, platform=macOS
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=iOS
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=watchOS
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=tvOS
XFAIL: https://bugs.swift.org/browse/SR-9139, ProcedureKit, 4.2, 94193d, ProcedureKitCloud, platform=macOS
========================================
XFailures:
  XFAIL: https://bugs.swift.org/browse/SR-9139, ProcedureKit, 4.2, 94193d, ProcedureKitCloud, platform=macOS
========================================
Action Summary:
     Passed: 4
     Failed: 0
    XFailed: 1
    UPassed: 0
      Total: 5
========================================
Repository Summary:
      Total: 1
========================================
Result: XFAIL
========================================
--- ProcedureKit checked successfully against Swift 4.2 ---
```