### PR TITLE
Update RxDataSources to build against Swift 4.2

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1989,8 +1989,8 @@
     "maintainer": "krunoslav.zaher@gmail.com",
     "compatibility": [
       {
-        "version": "3.0",
-        "commit": "c06ebe2207ed3a74d69a9d9b9bb59b48b64a09b4"
+        "version": "4.2",
+        "commit": "5458733cb4d2a1ca6a457804921a5fac4b72fca2"
       }
     ],
     "platforms": [
@@ -1998,37 +1998,8 @@
     ],
     "actions": [
       {
-        "action": "BuildXcodeProjectTarget",
-        "project": "Pods/Pods.xcodeproj",
-        "target": "Pods-RxDataSources",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8271"
-              }
-            }
-          }
-        }
-      },
-      {
-        "action": "BuildXcodeProjectTarget",
-        "project": "Pods/Pods.xcodeproj",
-        "target": "Pods-Example",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8271"
-              }
-            }
-          }
-        }
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

Updates the RxDataSources configuration to use SwiftPM. The Xcode project configurations were removed because of a missing RxSwift dependency.

- [x] pass `./project_precommit_check` script run

```
$ ./project_precommit_check RxDataSources --earliest-compatible-swift-version 4.2
** CHECK **
--- Validating RxDataSources Swift version 4.2 compatibility ---
--- Project configured to be compatible with Swift 4.2 ---
--- Checking RxDataSources platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcodes/PublicGMs/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ ./runner.py --swift-branch swift-4.2-branch --swiftc /Applications/Xcodes/PublicGMs/Xcode-10-GM.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "RxDataSources"' --include-versions 'version == "4.2"' --include-actions 'action.startswith("Build")'
PASS: RxDataSources, 4.2, 545873, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- RxDataSources checked successfully against Swift 4.2 ---
```