### PR TITLE
[Add] PlanGrid/ReactiveLists

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1886,8 +1886,8 @@
     "maintainer": "ios.developer@plangrid.com",
     "compatibility": [
       {
-        "version": "4.2",
-        "commit": "2f06131ada093cccd411454ddab9a7dba24a9007"
+        "version": "5.0",
+        "commit": "40fe60af98138394e210672ccf31386c3ca0c951"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -833,38 +833,6 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/plangrid/ReactiveLists.git",
-    "path": "ReactiveLists",
-    "branch": "master",
-    "maintainer": "ios.developer@plangrid.com",
-    "compatibility": [
-      {
-        "version": "4.2",
-        "commit": "7811400344880c545743564db202d59d1eabf7a5"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "ReactiveLists.xcworkspace",
-        "target": "ReactiveLists",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "tags": "sourcekit"
-      },
-      {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "ReactiveLists.xcworkspace",
-        "scheme": "ReactiveListsTests",
-        "destination": "platform=iOS Simulator,name=iPhone X"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/jessesquires/JSQCoreDataKit.git",
     "path": "JSQCoreDataKit",
     "branch": "master",
@@ -1907,6 +1875,38 @@
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/plangrid/ReactiveLists.git",
+    "path": "ReactiveLists",
+    "branch": "master",
+    "maintainer": "ios.developer@plangrid.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "7811400344880c545743564db202d59d1eabf7a5"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveLists.xcworkspace",
+        "scheme": "ReactiveLists",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "TestXcodeWorkspaceScheme",
+        "workspace": "ReactiveLists.xcworkspace",
+        "scheme": "ReactiveListsTests",
+        "destination": "platform=iOS Simulator,name=iPhone X"
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -1887,7 +1887,7 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "7811400344880c545743564db202d59d1eabf7a5"
+        "commit": "2f06131ada093cccd411454ddab9a7dba24a9007"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -833,6 +833,38 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/plangrid/ReactiveLists.git",
+    "path": "ReactiveLists",
+    "branch": "master",
+    "maintainer": "ios.developer@plangrid.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "7811400344880c545743564db202d59d1eabf7a5"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveLists.xcworkspace",
+        "target": "ReactiveLists",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "TestXcodeWorkspaceScheme",
+        "workspace": "ReactiveLists.xcworkspace",
+        "scheme": "ReactiveListsTests",
+        "destination": "platform=iOS Simulator,name=iPhone X"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/jessesquires/JSQCoreDataKit.git",
     "path": "JSQCoreDataKit",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Adds [ReactiveLists](https://github.com/plangrid/ReactiveLists) to the suite, which is used in the PlanGrid iOS app.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.