### PR TITLE
Add Xcode 10.1 configuration to project_precommit_check

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -72,6 +72,13 @@ supported_configs = {
                        'Target: x86_64-apple-darwin17.7.0\n',
             'description': 'Xcode 10.0 (contains Swift 4.2)',
             'branch': 'swift-4.2-branch'
+        },
+        '4.2.1': {
+            'version': 'Apple Swift version 4.2.1 '
+                       '(swiftlang-1000.11.42 clang-1000.11.45.1)\n'
+                       'Target: x86_64-apple-darwin17.7.0\n',
+            'description': 'Xcode 10.1 (contains Swift 4.2.1)',
+            'branch': 'swift-4.2-branch'
         }
     },
     # NOTE: Linux isn't fully supported yet


### PR DESCRIPTION
Adds Swift version 4.2.1 to `project_precommit_check`, to run with Xcode 10.1 selected.