### PR TITLE
Fix builder factory to handle Swift version 4.2 correctly

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -303,8 +303,19 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
 
         other_swift_flags = []
         if swift_version:
-            other_swift_flags += ['-swift-version', swift_version.split('.')[0]]
-            initial_xcodebuild_flags += ['SWIFT_VERSION=%s' % swift_version.split('.')[0]]
+            if '.' not in swift_version:
+                swift_version += '.0'
+
+            major, minor = swift_version.split('.', 1)
+            # Need to use float for minor version parsing
+            # because it's possible that it would be specified
+            # as e.g. `4.0.3`
+            if int(major) == 4 and float(minor) == 2.0:
+                other_swift_flags += ['-swift-version', swift_version]
+                initial_xcodebuild_flags += ['SWIFT_VERSION=%s' % swift_version]
+            else:
+                other_swift_flags += ['-swift-version', major]
+                initial_xcodebuild_flags += ['SWIFT_VERSION=%s' % major]
         if added_swift_flags:
             other_swift_flags.append(added_swift_flags)
         if other_swift_flags:
@@ -982,7 +993,7 @@ class CompatActionBuilder(ActionBuilder):
                 return None
 
         if not self.swift_version:
-            self.swift_version = self.version['version'].split('.')[0]
+            self.swift_version = self.version['version']
         try:
             dispatch(self.root_path, self.project, self.action,
                      self.swiftc,

--- a/projects.json
+++ b/projects.json
@@ -33,7 +33,7 @@
     "maintainer": "cnoon@alamofire.org",
     "compatibility": [
       {
-        "version": "4.2",
+        "version": "4.0",
         "commit": "a5cd9e233f24df3583f4b02f7e4722c076ab9032"
       }
     ],
@@ -576,7 +576,7 @@
     "maintainer": "brent@ranchero.com",
     "compatibility": [
       {
-        "version": "4.2",
+        "version": "4.0",
         "commit": "ce0d2450b83ec8c5dee6bb9c612b3eb06ba39c47"
       }
     ],
@@ -950,7 +950,7 @@
     "maintainer": "appledev@kickstarter.com",
     "compatibility": [
       {
-        "version": "4.2",
+        "version": "4.0",
         "commit": "8988b02ab963294d98d8f37d1a7dc0ee392fcd8d"
       }
     ],
@@ -2850,7 +2850,7 @@
     "maintainer": "contact@alexruperez.com",
     "compatibility": [
       {
-        "version": "4.2",
+        "version": "4.0",
         "commit": "f168b4fd2757cbda7092c3db8685dc2854b80003"
       }
     ],

--- a/projects.json
+++ b/projects.json
@@ -1683,18 +1683,7 @@
         "target": "ProcedureKitCloud",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9139",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9139",
-                "swift-4.2-branch": "https://bugs.swift.org/browse/SR-9139"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestXcodeProjectTarget",


### PR DESCRIPTION
Currently if both major and minor versions as specified minor would
be stripped out and only major gets set in actual `xcodebuild` flags,
but `4.2` is a valid version which has to be supported.