### PR TITLE
Add LineSDK to compatibility suite

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1196,6 +1196,40 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/line/line-sdk-ios-swift.git",
+    "path": "line-sdk-ios-swift",
+    "branch": "master",
+    "maintainer": "dl_linesdk_cocoapods@linecorp.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "d8bb2bc535e2895b5fbe66f4872327b654d19a34"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "LineSDK.xcworkspace",
+        "scheme": "LineSDK",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9375"
+              }
+            }
+          }
+        }
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/ssamadgh/ModelAssistant.git",
     "path": "ModelAssistant",
     "branch": "master",
@@ -3195,31 +3229,6 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "tags": "sourcekit"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
-    "url": "https://github.com/line/line-sdk-ios-swift.git",
-    "path": "line-sdk-ios-swift",
-    "branch": "master",
-    "maintainer": "dl_linesdk_cocoapods@linecorp.com",
-    "compatibility": [
-      {
-        "version": "4.2",
-        "commit": "d8bb2bc535e2895b5fbe66f4872327b654d19a34"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "LineSDK.xcworkspace",
-        "scheme": "LineSDK",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
       }
     ]
   }

--- a/projects.json
+++ b/projects.json
@@ -3197,5 +3197,30 @@
         "tags": "sourcekit"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/line/line-sdk-ios-swift.git",
+    "path": "line-sdk-ios-swift",
+    "branch": "master",
+    "maintainer": "dl_linesdk_cocoapods@linecorp.com",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "d8bb2bc535e2895b5fbe66f4872327b654d19a34"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "LineSDK.xcworkspace",
+        "scheme": "LineSDK",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

This PR contains the setting for LineSDK project (https://github.com/line/line-sdk-ios-swift).

It is suggested by @jrose-apple in https://bugs.swift.org/browse/SR-9375 and contains a crash for Swift 5 toolchain (Swift Development Snapshot 2018-11-28 (a)).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.