### PR TITLE
Keep ModelAssistant XFAILed on swift-5.0-branch.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1215,7 +1215,16 @@
         "project": "ModelAssistant.xcodeproj",
         "scheme": "ModelAssistant iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9102"
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
...until we cherry-pick a fix there.
