### PR TITLE
Revert "Keep ModelAssistant XFAILed on swift-5.0-branch."

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1215,16 +1215,7 @@
         "project": "ModelAssistant.xcodeproj",
         "scheme": "ModelAssistant iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9102"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
Un-XFAIL ModelAssistant on the swift-5.0-branch once
https://github.com/apple/swift/pull/20971 is merged.
