### PR TITLE
Update the SourceKit stress tester run script for recent changes to the stress tester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ swift-corelibs-libdispatch/
 swift-corelibs-xctest/
 swiftpm/
 swift-stress-tester/
+swift-syntax/

--- a/cleanup
+++ b/cleanup
@@ -52,7 +52,8 @@ def main():
         'swift-corelibs-foundation',
         'swift-corelibs-libdispatch',
         'swift-corelibs-xctest',
-        'swift-stress-tester'
+        'swift-stress-tester',
+        'swift-syntax'
     ]
 
     if args.cleanup_cache:

--- a/projects.json
+++ b/projects.json
@@ -239,8 +239,7 @@
         "workspace": "Chatto.xcworkspace",
         "scheme": "Chatto",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "Release"
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -359,7 +358,7 @@
         "scheme": "CoreStore OSX",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -820,7 +819,7 @@
         "scheme": "IBAnimatable",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -1985,7 +1984,7 @@
         "scheme": "RxSwift-macOS",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",

--- a/projects.json
+++ b/projects.json
@@ -430,7 +430,7 @@
         "scheme": "Cub macOS Release [Double]",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit"
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -2257,8 +2257,7 @@
         "project": "Surge.xcodeproj",
         "scheme": "Surge-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -2273,16 +2272,14 @@
         "project": "Surge.xcodeproj",
         "scheme": "Surge-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "Surge.xcodeproj",
         "scheme": "Surge-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "Release"
       }
     ]
   },

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -40,15 +40,11 @@ def main():
 
     if not args.skip_tools_clone:
         common.clone_repos()
-
-    if not args.skip_stress_tester_clone:
+        clone_swift_syntax(workspace, args.swift_branch)
         clone_stress_tester(workspace, args.swift_branch)
 
     if not args.skip_tools_build:
         build_swift_toolchain(workspace, args)
-
-    if not args.skip_stress_tester_build:
-        build_stress_tester(workspace, args)
 
     if not args.skip_runner:
         if not execute_runner(workspace, args):
@@ -73,9 +69,6 @@ def parse_args():
                         metavar='PATH',
                         help='JSON file specifying expected sourcekit failures',
                         default='sourcekit-xfails.json')
-    parser.add_argument('--gen-sourcekit-xfails',
-                        metavar='PATH',
-                        help='write any sourcekit failures encountered out to <PATH> in JSON; if --sourcekit-xfails is also specified, the union of its contents and any unexpected failures will be written instead')
     parser.add_argument('--verbose',
                         action='store_true')
     parser.add_argument('--assertions',
@@ -89,13 +82,9 @@ def parse_args():
                         help='swiftc executable')
     parser.add_argument('--skip-tools-build',
                         action='store_true')
-    parser.add_argument('--skip-stress-tester-build',
-                        action='store_true')
     parser.add_argument('--skip-ci-steps',
                         action='store_true')
     parser.add_argument('--skip-tools-clone',
-                        action='store_true')
-    parser.add_argument('--skip-stress-tester-clone',
                         action='store_true')
     parser.add_argument('--skip-runner',
                         action='store_true')
@@ -113,20 +102,12 @@ def parse_args():
                         default='')
     return parser.parse_args()
 
-def get_swiftsyntax_path(workspace):
-    parent_dir = os.path.join(workspace, 'build/compat_macos/')
-    matching = [x for x in os.listdir(parent_dir) if x.startswith("swiftsyntax")]
-    return os.path.join(parent_dir, matching[0], 'release')
-
 def get_swiftc_path(workspace, swiftc):
     swiftc_path = (
         swiftc if swiftc else
         os.path.join(workspace, 'build/compat_macos/install/toolchain/usr/bin/swiftc')
     )
     return swiftc_path
-
-def get_stress_test_path(workspace):
-    return os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester/.build/release/sk-stress-test')
 
 def get_sandbox_profile_flags():
     return [
@@ -136,39 +117,27 @@ def get_sandbox_profile_flags():
         '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_package.sb'
     ]
 
-def get_sandbox_profile_flags_test():
-    return [
-        '--sandbox-profile-xcodebuild',
-        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_xcodebuild.sb',
-        '--sandbox-profile-package',
-        '../../../workspace-private/swift-source-compat-suite-sandbox/sandbox_test.sb'
-    ]
-
 def clone_stress_tester(workspace, swift_branch):
-    syntax_clone_cmd = [
-        'git','clone', '-q', '-b', swift_branch, '--recursive',
-        'https://github.com/apple/swift-syntax',
-        '{}/swift-syntax'.format(workspace)
-    ]
-    common.check_execute(syntax_clone_cmd, timeout=-1)
     stress_clone_cmd = [
         'git','clone', '-q', '-b', swift_branch, '--recursive',
         'https://github.com/apple/swift-stress-tester',
         '{}/swift-stress-tester'.format(workspace)
     ]
     common.check_execute(stress_clone_cmd, timeout=-1)
+
+def clone_swift_syntax(workspace, swift_branch):
+    syntax_clone_cmd = [
+        'git','clone', '-q', '-b', swift_branch, '--recursive',
+        'https://github.com/apple/swift-syntax',
+        '{}/swift-syntax'.format(workspace)
+    ]
+    common.check_execute(syntax_clone_cmd, timeout=-1)
     
 
 def execute_runner(workspace, args):
     swiftc_path = get_swiftc_path(workspace, args.swiftc)
-    wrapper_path = os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester/.build/release/sk-swiftc-wrapper')
-    wrapper_link = os.path.join(os.path.dirname(swiftc_path), 'sk-swiftc-wrapper')
-
-    # copy stress tester wrapper alongside the underlying swiftc
-    # as swiftpm seems to look for other tools relative to the provided swiftc
-    if os.path.lexists(wrapper_link):
-        os.unlink(wrapper_link)
-    os.symlink(wrapper_path, wrapper_link)
+    wrapper_path = os.path.join(os.path.dirname(swiftc_path), 'sk-swiftc-wrapper')
+    stress_tester_path = os.path.join(os.path.dirname(swiftc_path), 'sk-stress-test')
 
     extra_runner_args = []
     if args.sandbox:
@@ -183,14 +152,9 @@ def execute_runner(workspace, args):
     if args.filter_by_tag:
         extra_runner_args += ['--include-actions', '"tags" in locals() and "{}" in tags.split()'.format(args.filter_by_tag)]
 
+    runner = StressTesterRunner(wrapper_path, stress_tester_path, swiftc_path, args.projects, args.swift_branch, os.path.abspath(args.sourcekit_xfails))
+    passed = runner.run(extra_runner_args)
 
-    failure_manager = FailureManager(args.sourcekit_xfails, args.swift_branch)
-    runner = StressTesterRunner(wrapper_link, get_stress_test_path(workspace), swiftc_path, failure_manager)
-    passed = runner.run(args.projects, args.swift_branch, extra_runner_args)
-
-    # output failures as json if requested and the the underlying compatibility run succeeded.
-    if not runner.compat_runner_failed and args.gen_sourcekit_xfails:
-        failure_manager.write_failures(args.gen_sourcekit_xfails, update=True)
     return passed
 
 
@@ -203,6 +167,7 @@ def build_swift_toolchain(workspace, args):
         '--llbuild',
         '--swiftpm',
         '--swiftsyntax',
+        '--skstresstester',
         '--ios',
         '--tvos',
         '--watchos',
@@ -220,6 +185,8 @@ def build_swift_toolchain(workspace, args):
         '--install-llbuild',
         '--install-swift',
         '--install-swiftpm',
+        '--install-swiftsyntax',
+        '--install-skstresstester',
         '--install-destdir={}/build/compat_macos/install'.format(workspace),
         '--install-prefix=/toolchain/usr',
         '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
@@ -233,214 +200,74 @@ def build_swift_toolchain(workspace, args):
     common.check_execute(build_command, timeout=9999999)
 
 
-def build_stress_tester(workspace, args):
-    swiftc_path = get_swiftc_path(workspace, args.swiftc)
-    swiftsyntax_path = get_swiftsyntax_path(workspace)
-    bin_dir = os.path.dirname(swiftc_path)
-    lib_dir = os.path.join(os.path.dirname(bin_dir), 'lib')
-    swift = os.path.join(bin_dir, 'swift')
-    
-    build_command = [
-        swift, 'build',
-        '--package-path', os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester'),
-        '-c', 'release',
-        # to pick up SwiftSyntax
-        '-Xswiftc', '-lSwiftSyntax',
-        '-Xswiftc', '-I' + swiftsyntax_path,
-        '-Xswiftc', '-L' + swiftsyntax_path,
-        '-Xlinker', '-rpath', '-Xlinker', swiftsyntax_path,
-        # to pick up the sourcekitd framework
-        '-Xswiftc', '-Fsystem', '-Xswiftc', lib_dir,
-        '-Xlinker', '-rpath', '-Xlinker', lib_dir
-    ]
-    common.check_execute(build_command, timeout=999)
-
-class FailureKind(object):
-    """the kind of failure detected on a particular line of output."""
-    NONE = 1 
-    FAIL = 2
-    XFAIL = 3
-
-
-class FailureManager(object):
-    """parses and manages failures reported by the SourceKit stress tester."""
-
-    def __init__(self, xfails_path, swift_branch):
-        self.swift_branch = swift_branch
-        self.xfails_path = xfails_path
-        self.xfails = self._load_applicable_xfails(xfails_path, swift_branch) if xfails_path else []
-        self.seen_files = set()
-        self.expected = []
-        self.unexpected = []
-
-    def process_line(self, line):
-        prefix = '[stress-tester]'
-        if not line.startswith(prefix):
-            return FailureKind.NONE, None, None
-
-        message = json.loads(line[len(prefix):])
-        self.seen_files |= set(message['processedFiles'])
-
-        if not 'error' in message:
-            return FailureKind.NONE, None, None
-
-        error = message['error']
-        failure = {'branches': [self.swift_branch]}
-        for key, value in error['request'].items():
-            if key == 'document':
-                failure['file'] = value['path']
-                if 'modification' in value:
-                    modification = value['modification']
-                    failure['modification'] = '{}:{}'.format(modification['mode'], len(modification['content']))
-            elif key != 'args' and value is not None:
-                failure[key] = value
-
-        if self._is_expected_failure(failure):
-            self.expected.append(failure)
-            return FailureKind.XFAIL, failure, error
-
-        self.unexpected.append(failure)
-        return FailureKind.FAIL, failure, error
-
-    @property
-    def unmatched_xfails(self):
-        return [xfail for xfail in self.xfails if not xfail.get('_matched', False) and self._saw_matching_file(xfail.get('file'))]
-
-    def write_failures(self, path, update=False):
-        with open(path, 'w') as json_out:
-            failures = self.unexpected + (self.xfails if update and self.xfails else self.expected)
-            failures.sort(key=lambda f: f.get('file', ''))
-            json.dump([{key: value for key, value in failure.items() if not key.startswith('_')} for failure in failures], json_out, indent=4)
-
-    def _is_expected_failure(self, failure):
-        return any(self._xfail_matches(failure, xfail) for xfail in self.xfails)
-
-    def _saw_matching_file(self, xfail_file):
-        if not xfail_file:
-            return True
-        return any(re.match(self._wildcard_to_regex(xfail_file), seen_file) for seen_file in self.seen_files)
-
-    @classmethod
-    def _xfail_matches(cls, failure, xfail):
-      for key, value in xfail.items():
-        if key.startswith('_') or key in ['issue', 'branches']:
-          continue
-        if key in failure and re.match(cls._wildcard_to_regex(str(value)), str(failure[key])):
-          continue
-        return False
-
-      xfail['_matched'] = True
-      if 'issue' in xfail:
-        failure['issue'] = xfail['issue']
-      return True
-
-    @staticmethod
-    def _load_applicable_xfails(xfails_path, swift_branch):
-        with open(xfails_path) as json_file:
-            return [xfail for xfail in json.load(json_file) if swift_branch in xfail['branches']]
-
-    @staticmethod
-    def _wildcard_to_regex(wildcard_string):
-      regex_parts = [re.escape(item) for item in wildcard_string.split('*')]
-      return r'.*'.join(regex_parts) + r'$'
-
-
 class StressTesterRunner(object):
     """sets up the Swift compatibility suite runner to use the stress tester's swiftc-wrapper, executes it, and processes its output for failures."""
 
-    def __init__(self, wrapper, stress_tester, swiftc, failure_manager):
+    def __init__(self, wrapper, stress_tester, swiftc, projects, branch, xfails):
         self.wrapper = wrapper
         self.stress_tester = stress_tester
         self.swiftc = swiftc
 
-        self.failure_manager = failure_manager
+        self.xfails_path = xfails
+        self.projects_path = projects
+        self.swift_branch = branch
+
         self.compat_runner_failed = False
 
-    def run(self, projects_json, swift_branch, extra_runner_args=[]):
+
+    def run(self, extra_runner_args=[]):
+        # temporary file paths
+        filtered_projects = os.path.join(script_dir, 'stress-tester-projects.json')
+        results = os.path.join(script_dir, 'stress-tester-results.json')
+
+        # remove temporary files if they already exist
+        self._cleanup([filtered_projects, results])
+
         run_env = {
             'SK_STRESS_TEST': self.stress_tester,
             'SK_STRESS_SWIFTC': self.swiftc,
             'SK_STRESS_SILENT': 'true',
             'SK_STRESS_AST_BUILD_LIMIT': '1000',
-            'SK_STRESS_MACHINE': 'true' }
+            'SK_STRESS_OUTPUT': results,
+            'SK_XFAILS_PATH': self.xfails_path,
+            'SK_STRESS_ACTIVE_CONFIG': self.swift_branch}
         run_env.update(os.environ)
-        filtered_projects_json = self._rewrite_projects_json(projects_json, os.path.join(script_dir, 'stress-tester-projects.json'))
-
-        run_cmd = ['python', '-u', 'runner.py',
-          '--projects', filtered_projects_json,
+        run_cmd = ['./runner.py',
+          '--projects', filtered_projects,
           '--verbose',
           '--swiftc', self.wrapper,
-          '--swift-branch', swift_branch,
+          '--swift-branch', self.swift_branch,
           '--default-timeout', str(-1),
           '--only-latest-versions',
-          # archs overrie is set to arm64 for generic/iOS actions that would otherwise invoke the stress tester for both arm64 and armv7
+          # archs override is set to arm64 for generic/iOS actions that would otherwise invoke the stress tester for both arm64 and armv7
           '--add-xcodebuild-flags', 'ARCHS={archs_override}']
 
         if extra_runner_args:
             run_cmd.extend(extra_runner_args)
 
+        self._filter_projects(filtered_projects)
         try:
-            for line in check_output_lines(run_cmd, env=run_env):
-                self._process_line(line)
-        except subprocess.CalledProcessError:
+            common.check_execute(run_cmd, timeout=-1, env=run_env)
+        except common.ExecuteCommandFailure:
             self.compat_runner_failed = True
 
-        self._print_summary(swift_branch)
-        return self._succeeded
+        success = self._process_output(results)
 
-    @property
-    def _succeeded(self):
-        return not self.compat_runner_failed and (len(self.failure_manager.unexpected) == len(self.failure_manager.unmatched_xfails) == 0)
+        return success
 
-    def _process_line(self, line):
-        (kind, failure, error) = self.failure_manager.process_line(line)
-        if kind == FailureKind.XFAIL:
-            print('XFAIL: {}'.format(failure['issue'] if 'issue' in failure else '<missing issue>'))
-            return
-        elif kind == FailureKind.FAIL:
-            self._print_failure_instructions(failure)
-        else:
-            print(line)
 
-    def _print_failure_instructions(self, failure):
-        example = {'issue': '<issue url>'}
+    def _process_output(self, results_path):
+        if not os.path.isfile(results_path):
+            return True
 
-        file_parts = failure['file'].split('/')
-        example['file'] = file_parts[0] + '/*' if len(file_parts) > 1 else '*'
-        project_json = json.dumps(example, indent=2)
+        with open(results_path) as results_file:
+            results = json.load(results_file)
 
-        example['file'] = failure['file']
-        file_json = json.dumps(example, indent=2)
+        num_failures = len(results['failures'])
+        num_xfails = len(results['expectedFailures'])
+        unmatched = results['unmatchedExpectedFailures']
 
-        example.update(failure)
-        exact_json = json.dumps(example, indent=2)
-
-        xfails_path = self.failure_manager.xfails_path        
-        path_text = ':\n  {}'.format(xfails_path) if xfails_path else '.'
-
-        print('''
-** STRESS TESTER FAILURE **
-
-Please file an issue against SourceKit with the failure details below and add
-an expected failure to the JSON file passed via the --xfail-json option{path}
-
-To mark this specific failure as expected, include the below:
-{exact}
-
-To mark all failures in the same file as expected, include:
-{file}
-
-Or to mark all failures in a directory as expected, use a wildcard:
-{project}
-
-Failure details:
-'''.format(path=path_text, exact=exact_json, file=file_json, project=project_json))
-
-    def _print_summary(self, swift_branch):
-        num_failures = len(self.failure_manager.unexpected)
-        num_xfails = len(self.failure_manager.expected)
-        unmatched = self.failure_manager.unmatched_xfails
-        xfails_path = self.failure_manager.xfails_path
+        success = num_failures == 0 and len(unmatched) == 0
 
         print('SourceKit Stress Tester summary:')
         
@@ -450,24 +277,25 @@ Failure details:
         
         print('  {} unexpected stress tester failures'.format(num_failures))
         if num_failures > 0:
-            print('      > search "** STRESS TESTER FAILURE **" for individual failures and filing instructions')
+            print('      > search "Detected unexpected failure:" for individual failures')
 
         print('  {} expected stress tester failures'.format(num_xfails))
 
         if not self.compat_runner_failed and unmatched:
             print('  {} expected stress tester failures not seen'.format(len(unmatched)))
-            print('      > if resolved, remove "{}" from "branches" in the following entries in {} or the entire entry if no branches remain:'.format(swift_branch, xfails_path))
+            print('      > if resolved, remove "{}" from "branches" in the following entries in {} or the entire entry if no branches remain:'.format(self.swift_branch, self.xfails_path))
             for xfail in unmatched:
                 print('      {}'.format(json.dumps(xfail)))
 
         print('========================================')
-        print('Result: {result}'.format(result=('PASS' if self._succeeded else 'FAIL')))
+        print('Result: {result}'.format(result=('PASS' if success else 'FAIL')))
         print('========================================')
 
+        return success
 
-    @staticmethod
-    def _rewrite_projects_json(current, output):
-        with open(current) as json_file:
+
+    def _filter_projects(self, output):
+        with open(self.projects_path) as json_file:
             projects = json.load(json_file)
             for project in projects:
                 for action in project['actions']:
@@ -479,19 +307,13 @@ Failure details:
             json.dump(projects, outfile, indent=4)
         return output
 
-def check_output_lines(cmd, env=None):
-    """a generator yielding each line the given command writes to stdout and stderr as it appears."""
-    common.shell_debug_print(cmd)
-
-    p = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True)
-    for line in iter(p.stdout.readline, ''):
-        yield line.rstrip()
-    p.stdout.close()
-
-    return_code = p.poll()
-    if return_code:
-        raise subprocess.CalledProcessError(return_code, cmd)
-
+    @staticmethod
+    def _cleanup(paths):
+        for path in paths:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -113,6 +113,10 @@ def parse_args():
                         default='')
     return parser.parse_args()
 
+def get_swiftsyntax_path(workspace):
+    parent_dir = os.path.join(workspace, 'build/compat_macos/')
+    matching = [x for x in os.listdir(parent_dir) if x.startswith("swiftsyntax")]
+    return os.path.join(parent_dir, matching[0], 'release')
 
 def get_swiftc_path(workspace, swiftc):
     swiftc_path = (
@@ -141,12 +145,18 @@ def get_sandbox_profile_flags_test():
     ]
 
 def clone_stress_tester(workspace, swift_branch):
-    clone_cmd = [
+    syntax_clone_cmd = [
+        'git','clone', '-q', '-b', swift_branch, '--recursive',
+        'https://github.com/apple/swift-syntax',
+        '{}/swift-syntax'.format(workspace)
+    ]
+    common.check_execute(syntax_clone_cmd, timeout=-1)
+    stress_clone_cmd = [
         'git','clone', '-q', '-b', swift_branch, '--recursive',
         'https://github.com/apple/swift-stress-tester',
         '{}/swift-stress-tester'.format(workspace)
     ]
-    common.check_execute(clone_cmd, timeout=9999999)
+    common.check_execute(stress_clone_cmd, timeout=-1)
     
 
 def execute_runner(workspace, args):
@@ -192,6 +202,7 @@ def build_swift_toolchain(workspace, args):
         '--build-ninja',
         '--llbuild',
         '--swiftpm',
+        '--swiftsyntax',
         '--ios',
         '--tvos',
         '--watchos',
@@ -214,7 +225,7 @@ def build_swift_toolchain(workspace, args):
         '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
         '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
         '--llvm-install-components=libclang;libclang-headers',
-        '--swift-install-components=compiler;clang-builtin-headers;stdlib;swift-syntax;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
+        '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
         '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
         '--verbose-build',
         '--reconfigure',
@@ -224,6 +235,7 @@ def build_swift_toolchain(workspace, args):
 
 def build_stress_tester(workspace, args):
     swiftc_path = get_swiftc_path(workspace, args.swiftc)
+    swiftsyntax_path = get_swiftsyntax_path(workspace)
     bin_dir = os.path.dirname(swiftc_path)
     lib_dir = os.path.join(os.path.dirname(bin_dir), 'lib')
     swift = os.path.join(bin_dir, 'swift')
@@ -232,7 +244,11 @@ def build_stress_tester(workspace, args):
         swift, 'build',
         '--package-path', os.path.join(workspace, 'swift-stress-tester/SourceKitStressTester'),
         '-c', 'release',
-        '-Xswiftc', '-target', '-Xswiftc', 'x86_64-apple-macosx10.13',
+        # to pick up SwiftSyntax
+        '-Xswiftc', '-lSwiftSyntax',
+        '-Xswiftc', '-I' + swiftsyntax_path,
+        '-Xswiftc', '-L' + swiftsyntax_path,
+        '-Xlinker', '-rpath', '-Xlinker', swiftsyntax_path,
         # to pick up the sourcekitd framework
         '-Xswiftc', '-Fsystem', '-Xswiftc', lib_dir,
         '-Xlinker', '-rpath', '-Xlinker', lib_dir
@@ -249,43 +265,42 @@ class FailureKind(object):
 class FailureManager(object):
     """parses and manages failures reported by the SourceKit stress tester."""
 
-    _error_matcher = re.compile(r'\[sk-stress-test\] error: (?P<failure>[^ ]+) invoking SourceKit request (?P<request>[^ ]+)(?: \((?P<refactoring>[^\)]+)\))? [oi]n .*/project_cache/(?P<file>.+\.swift)(?: a[ts] offset (?P<offset>\d+)(?: for length (?P<length>\d+))? with args:.*)?$')
-    _seen_matcher = re.compile(r'\[sk-stress-test\] Stress testing .*/project_cache/(?P<file>.+\.swift)(?: part \d+ of \d+):$')
-
     def __init__(self, xfails_path, swift_branch):
         self.swift_branch = swift_branch
         self.xfails_path = xfails_path
         self.xfails = self._load_applicable_xfails(xfails_path, swift_branch) if xfails_path else []
-        self.seen_files = []
+        self.seen_files = set()
         self.expected = []
         self.unexpected = []
-        self.unrecognized_errors = []
 
     def process_line(self, line):
-        match = self._error_matcher.search(line)
-        if not match:
-            if line.startswith('[sk-stress-test] error:'):
-                self.unrecognized_errors.append(line)
-            else:
-                # keep track of files we actually stress test so we don't report unmatched xfails in files we didn't see
-                progress = self._seen_matcher.search(line)
-                if progress:
-                    self.seen_files.append(progress.groupdict()['file'])
-            return FailureKind.NONE, None
+        prefix = '[stress-tester]'
+        if not line.startswith(prefix):
+            return FailureKind.NONE, None, None
 
-        failure = {key: value for key, value in match.groupdict().items() if value is not None}
-        failure['branches'] = [self.swift_branch]
+        message = json.loads(line[len(prefix):])
+        self.seen_files |= set(message['processedFiles'])
 
-        for key in ['offset', 'length']:
-            if key in failure:
-                failure[key] = int(failure[key])
+        if not 'error' in message:
+            return FailureKind.NONE, None, None
+
+        error = message['error']
+        failure = {'branches': [self.swift_branch]}
+        for key, value in error['request'].items():
+            if key == 'document':
+                failure['file'] = value['path']
+                if 'modification' in value:
+                    modification = value['modification']
+                    failure['modification'] = '{}:{}'.format(modification['mode'], len(modification['content']))
+            elif key != 'args' and value is not None:
+                failure[key] = value
 
         if self._is_expected_failure(failure):
             self.expected.append(failure)
-            return FailureKind.XFAIL, failure
-        
+            return FailureKind.XFAIL, failure, error
+
         self.unexpected.append(failure)
-        return FailureKind.FAIL, failure
+        return FailureKind.FAIL, failure, error
 
     @property
     def unmatched_xfails(self):
@@ -308,7 +323,7 @@ class FailureManager(object):
     @classmethod
     def _xfail_matches(cls, failure, xfail):
       for key, value in xfail.items():
-        if key in ['issue', 'branches', '_matched']:
+        if key.startswith('_') or key in ['issue', 'branches']:
           continue
         if key in failure and re.match(cls._wildcard_to_regex(str(value)), str(failure[key])):
           continue
@@ -345,8 +360,9 @@ class StressTesterRunner(object):
         run_env = {
             'SK_STRESS_TEST': self.stress_tester,
             'SK_STRESS_SWIFTC': self.swiftc,
-            'SK_STRESS_SILENT': '',
-            'SK_STRESS_CODECOMPLETE_LIMIT': '1000' }
+            'SK_STRESS_SILENT': 'true',
+            'SK_STRESS_AST_BUILD_LIMIT': '1000',
+            'SK_STRESS_MACHINE': 'true' }
         run_env.update(os.environ)
         filtered_projects_json = self._rewrite_projects_json(projects_json, os.path.join(script_dir, 'stress-tester-projects.json'))
 
@@ -355,7 +371,7 @@ class StressTesterRunner(object):
           '--verbose',
           '--swiftc', self.wrapper,
           '--swift-branch', swift_branch,
-          '--default-timeout', str(180*60),
+          '--default-timeout', str(-1),
           '--only-latest-versions',
           # archs overrie is set to arm64 for generic/iOS actions that would otherwise invoke the stress tester for both arm64 and armv7
           '--add-xcodebuild-flags', 'ARCHS={archs_override}']
@@ -377,13 +393,14 @@ class StressTesterRunner(object):
         return not self.compat_runner_failed and (len(self.failure_manager.unexpected) == len(self.failure_manager.unmatched_xfails) == 0)
 
     def _process_line(self, line):
-        (kind, failure) = self.failure_manager.process_line(line)
+        (kind, failure, error) = self.failure_manager.process_line(line)
         if kind == FailureKind.XFAIL:
-            print('[XFAIL][{}]{}'.format(failure['issue'] if 'issue' in failure else '<missing issue>', line))
+            print('XFAIL: {}'.format(failure['issue'] if 'issue' in failure else '<missing issue>'))
             return
-        print(line)
-        if kind == FailureKind.FAIL:
+        elif kind == FailureKind.FAIL:
             self._print_failure_instructions(failure)
+        else:
+            print(line)
 
     def _print_failure_instructions(self, failure):
         example = {'issue': '<issue url>'}
@@ -404,9 +421,8 @@ class StressTesterRunner(object):
         print('''
 ** STRESS TESTER FAILURE **
 
-Please file an issue against SourceKit with the '[sk-stress-test] error:'
-line above and add an expected failure to the JSON file passed via the
---xfail-json option{path}
+Please file an issue against SourceKit with the failure details below and add
+an expected failure to the JSON file passed via the --xfail-json option{path}
 
 To mark this specific failure as expected, include the below:
 {exact}
@@ -416,6 +432,8 @@ To mark all failures in the same file as expected, include:
 
 Or to mark all failures in a directory as expected, use a wildcard:
 {project}
+
+Failure details:
 '''.format(path=path_text, exact=exact_json, file=file_json, project=project_json))
 
     def _print_summary(self, swift_branch):
@@ -423,7 +441,6 @@ Or to mark all failures in a directory as expected, use a wildcard:
         num_xfails = len(self.failure_manager.expected)
         unmatched = self.failure_manager.unmatched_xfails
         xfails_path = self.failure_manager.xfails_path
-        unrecognized_errors = self.failure_manager.unrecognized_errors
 
         print('SourceKit Stress Tester summary:')
         
@@ -442,10 +459,6 @@ Or to mark all failures in a directory as expected, use a wildcard:
             print('      > if resolved, remove "{}" from "branches" in the following entries in {} or the entire entry if no branches remain:'.format(swift_branch, xfails_path))
             for xfail in unmatched:
                 print('      {}'.format(json.dumps(xfail)))
-
-        if unrecognized_errors:
-            print('  {} unrecognised stress tester errors (warning)'.format(len(unrecognized_errors)))
-            print('      > the SourceKit stress tester reported errors this script doesn\'t yet recognize')
 
         print('========================================')
         print('Result: {result}'.format(result=('PASS' if self._succeeded else 'FAIL')))

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1,724 +1,1090 @@
 [
   {
-    "branches": ["master"],
-    "file": "Alamofire/Source/AFError.swift",
-    "offset": 2817,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8812"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Alamofire/Source/Alamofire.swift",
-    "offset": 3719,
-    "length": 9,
-    "request": "RangeInfo",
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "AsyncNinja/Sources/BaseProducer.swift",
-    "offset": 1146,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "AsyncNinja/Sources/BaseProducer.swift",
-    "offset": 1773,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "BlueSocket/Sources/Socket.swift",
-    "offset": 30861,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Chatto/ChattoAdditions/Source/Chat Items/BaseMessage/BaseMessageModel.swift",
-    "offset": 1128,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 12,
-    "file": "Chatto/Chatto/Source/Chat Items/ChatItemCompanion.swift",
-    "offset": 1580,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 34,
-    "file": "Chatto/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift",
-    "offset": 8369,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 8,
-    "file": "CleanroomLogger/Sources/ConcatenatingLogFormatter.swift",
-    "offset": 2348,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 22,
-    "file": "CoreStore/Sources/CSDataStack+Observing.swift",
-    "offset": 3048,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 13,
-    "file": "cub/Sources/Cub/AST/Nodes/ArrayNode.swift",
-    "offset": 758,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "failure": "crashed",
-    "length": 16,
-    "file": "DNS/Sources/DNS/Bytes.swift",
-    "offset": 6663,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 24,
-    "file": "Deferred/Sources/Deferred/Deferred.swift",
-    "offset": 2331,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Deferred/Sources/Task/TaskAndThen.swift",
-    "offset": 2614,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/submodules/RSCore/RSCore/AppKit/LogWindowController.swift",
-    "offset": 167,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 18,
-    "file": "Evergreen/submodules/RSCore/RSCore/RSToolbarItem.swift",
-    "offset": 1174,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/submodules/RSParser/Sources/Feeds/FeedType.swift",
-    "offset": 705,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 17,
-    "file": "Evergreen/submodules/RSDatabase/RSDatabase/DatabaseObject.swift",
-    "offset": 649,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 24,
-    "file": "Evergreen/submodules/RSWeb/RSWeb/DownloadSession.swift",
-    "offset": 3145,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/submodules/RSTree/RSTree/NSOutlineView+RSTree.swift",
-    "offset": 166,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/submodules/RSWeb/RSWeb/Credentials.swift",
-    "offset": 152,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Evergreen/Frameworks/Data/DatabaseID.swift",
-    "offset": 488,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/Frameworks/Data/Article.swift",
-    "offset": 151,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/Frameworks/Database/ArticlesTable.swift",
-    "offset": 162,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/Frameworks/Account/Account.swift",
-    "offset": 156,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/AppleEvents/AppleEventUtils.swift",
-    "offset": 158,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 24,
-    "file": "Evergreen/Frameworks/Account/Account.swift",
-    "offset": 2653,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 20,
-    "file": "Evergreen/Commands/DeleteFromSidebarCommand.swift",
-    "offset": 2831,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "SemanticRefactoring",
-    "refactoring": "Convert To Trailing Closure",
-    "file": "exercism-*swift/exercises/word-count/Sources/WordCountExample.swift",
-    "offset": 97,
-    "issue": "https://github.com/apple/swift/pull/17291 (fixed on master; rdar://problem/41093898)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "exercism-*swift/exercises/acronym/Sources/AcronymExample.swift",
-    "offset": 913,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "fluent/Sources/Fluent/Cache/CacheEntry.swift",
-    "offset": 534,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8042"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "fluent/Sources/FluentBenchmark/Benchmarks/Bar.swift",
-    "offset": 240,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8042"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "GRDB.swift/GRDB/Core/Cursor.swift",
-    "offset": 22555,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallBeat.swift",
-    "offset": 2007,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallPulseRise.swift",
-    "offset": 2460,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18665 (fixed on master; rdar://problem/42639255)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "JSQDataSourcesKit/Source/ReusableViewConfig.swift",
-    "offset": 6930,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/commit/398abdfb (fixed on master; rdar://problem/41175473)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 26,
-    "file": "KeychainAccess/Lib/KeychainAccess/Keychain.swift",
-    "offset": 18237,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Kickstarter-Prelude/Prelude/Optional.swift",
-    "offset": 1585,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/17339 (fixed on master; rdar://problem/41219750)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Kickstarter-Prelude/Prelude-UIKit/UIImage.swift",
-    "offset": 309,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Kickstarter-ReactiveExtensions/Frameworks/ReactiveSwift/Sources/Action.swift",
-    "offset": 3959,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Kingfisher/Sources/Box.swift",
-    "offset": 1223,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Kingfisher/Sources/Image.swift",
-    "offset": 21272,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "SemanticRefactoring",
-    "refactoring": "Local Rename",
-    "file": "Kitura/Sources/Kitura/CodableRouter.swift",
-    "offset": 45420,
-    "issue": "https://bugs.swift.org/browse/SR-8566"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Kronos/Sources/DNSResolver.swift",
-    "offset": 3012,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 16,
-    "file": "Lark/Sources/Lark/Client.swift",
-    "offset": 6608,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 9,
-    "file": "Lark/Sources/CodeGenerator/Generator.swift",
-    "offset": 5239,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 16,
-    "file": "Moya/Sources/Moya/AnyEncodable.swift",
-    "offset": 233,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Moya/Sources/ReactiveMoya/MoyaProvider+Reactive.swift",
-    "offset": 382,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Moya/Sources/RxMoya/MoyaProvider+Rx.swift",
-    "offset": 1536,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18202 (fixed on master; rdar://problem/42448618)"
+    "path" : "*\/Alamofire\/Source\/Request.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/AsyncNinja\/Sources\/BaseProducer.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2560
+    }
+  },
+  {
+    "path" : "*\/AsyncNinja\/Sources\/EventSource_Merge2.swift",
+    "modification" : "concurrent-2781",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9378",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 2773
+    }
+  },
+  {
+    "path" : "*\/BeaconKit\/Sources\/BeaconKit\/Classes\/Parser\/LayoutFragment.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/BlueSocket\/Sources\/Socket\/Socket.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Chatto\/Chatto\/Source\/ChatController\/BaseChatViewController.swift",
+    "modification" : "concurrent-1515",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 1345
+    }
+  },
+  {
+    "path" : "*\/Chatto\/Chatto\/Source\/Utils.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Chatto\/ChattoAdditions\/Source\/Chat Items\/TextMessages\/Views\/TextMessageCollectionViewCellDefaultStyle.swift",
+    "modification" : "concurrent-2191",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9387",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2189
+    }
+  },
+  {
+    "path" : "*\/CoreStore\/Sources\/AsynchronousDataTransaction.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 6581
+    }
+  },
+  {
+    "path" : "*\/CoreStore\/Sources\/CoreStoreError.swift",
+    "modification" : "concurrent-4683",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 2769
+    }
+  },
+  {
+    "path" : "*\/DNS\/Sources\/DNS\/Integer+Data.swift",
+    "modification" : "concurrent-460",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 456
+    }
+  },
+  {
+    "path" : "*\/DNS\/Sources\/DNS\/Message.swift",
+    "modification" : "concurrent-9359",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 5567
+    }
+  },
+  {
+    "path" : "*\/Deferred\/Sources\/Deferred\/DeferredQueue.swift",
+    "modification" : "insideOut-2356",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 312
+    }
+  },
+  {
+    "path" : "*\/Deferred\/Sources\/Task\/ResultRecovery.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 606
+    }
+  },
+  {
+    "path" : "*\/Deferred\/Sources\/Task\/TaskAndThen.swift",
+    "modification" : "concurrent-893",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 887
+    }
+  },
+  {
+    "path" : "*\/Dollar\/Sources\/Dollar.swift",
+    "modification" : "concurrent-2573",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 2250
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/submodules\/RSDatabase\/RSDatabase\/DatabaseTable.swift",
+    "modification" : "insideOut-1034",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 821
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/submodules\/RSDatabase\/RSDatabase\/DatabaseTable.swift",
+    "modification" : "insideOut-1037",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 843
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/submodules\/RSTree\/RSTree\/Node.swift",
+    "modification" : "insideOut-2666",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2400
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/Frameworks\/Database\/Database.swift",
+    "modification" : "insideOut-32",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 3,
+      "text" : ":"
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/Commands\/DeleteFromSidebarCommand.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1583
+    }
+  },
+  {
+    "path" : "*\/Evergreen\/Evergreen\/ProgressWindow\/IndeterminateProgressWindowController.swift",
+    "modification" : "concurrent-1304",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1292
+    }
+  },
+  {
+    "path" : "*\/fluent\/Sources\/Fluent\/Cache\/CacheEntry.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9003",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 908
+    }
+  },
+  {
+    "path" : "*\/fluent\/Sources\/FluentBenchmark\/Benchmarks\/Bar.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9003",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 955
+    }
+  },
+  {
+    "path" : "*\/fluent\/Sources\/FluentSQL\/SQL+Contains.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 215
+    }
+  },
+  {
+    "path" : "*\/IBAnimatable\/Sources\/ActivityIndicators\/Animations\/ActivityIndicatorAnimationCircleDashStrokeSpin.swift",
+    "modification" : "concurrent-2290",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2284
+    }
+  },
+  {
+    "path" : "*\/IBAnimatable\/Sources\/Enums\/GradientType.swift",
+    "modification" : "insideOut-3275",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 3275,
+      "text" : "0.254901960784314"
+    }
+  },
+  {
+    "path" : "*\/KeychainAccess\/Lib\/KeychainAccess\/Keychain.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1436
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Prelude\/Either.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2903
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1436
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-ReactiveExtensions\/Frameworks\/ReactiveSwift\/Sources\/Action.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 4690
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-ReactiveExtensions\/ReactiveExtensions\/UIKit\/Rac.swift",
+    "modification" : "concurrent-495",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 458
+    }
+  },
+  {
+    "path" : "*\/Kickstarter-ReactiveExtensions\/ReactiveExtensions\/helpers\/DispatchTimeInterval-Extensions.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Kingfisher\/Sources\/Filter.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Kitura\/Sources\/Kitura\/CodableRouter.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-8566",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 45420
+    }
+  },
+  {
+    "path" : "*\/NetService\/Sources\/NetService\/Utils.swift",
+    "modification" : "insideOut-*",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371 TIMEOUT",
+    "request" : {
+      "kind" : "cursorInfo",
+    }
+  },
+  {
+    "path" : "*\/ObjectMapper\/Sources\/DictionaryTransform.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 626
+    }
+  },
+  {
+    "path" : "*\/ObjectMapper\/Sources\/EnumOperators.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Perfect\/Sources\/PerfectLib\/File.swift",
+    "modification" : "concurrent-4321",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 3543
+    }
+  },
+  {
+    "path" : "*\/Perfect\/Sources\/PerfectLib\/SysProcess.swift",
+    "modification" : "insideOut-279",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 63,
+      "text" : "&"
+    }
+  },
+  {
+    "path" : "*\/Plank\/Sources\/Core\/JSIR.swift",
+    "modification" : "insideOut-174",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 94,
+      "text" : " "
+    }
+  },
+  {
+    "path" : "*\/Plank\/Sources\/plank\/Cli.swift",
+    "modification" : "insideOut-2867",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 285,
+      "text" : "\""
+    }
+  },
+  {
+    "path" : "*\/ProcedureKit\/Sources\/ProcedureKit\/Any.swift",
+    "modification" : "concurrent-1715",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1148
+    }
+  },
+  {
+    "path" : "*\/PromiseKit\/Sources\/AnyPromise.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/R.swift\/Sources\/RswiftCore\/Generators\/AggregatedStructGenerator.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9015",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 856
+    }
+  },
+  {
+    "path" : "*\/R.swift\/Sources\/rswift\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 6857
+    }
+  },
+  {
+    "path" : "*\/Re-Lax\/ReLax\/ReLax\/ParallaxImage.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1798
+    }
+  },
+  {
+    "path" : "*\/ReSwift\/ReSwift\/CoreTypes\/Store.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 3943
+    }
+  },
+  {
+    "path" : "*\/ReactiveCocoa\/ReactiveCocoa\/AppKit\/NSButton.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/ReactiveSwift\/Sources\/Action.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 4690
+    }
+  },
+  {
+    "path" : "*\/ReactiveSwift\/Sources\/Action.swift",
+    "modification" : "concurrent-2061",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9017",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 1965
+    }
+  },
+  {
+    "path" : "*\/Result\/Result\/ResultProtocol.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/RxSwift\/RxSwift\/Deprecated.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 10051
+    }
+  },
+  {
+    "path" : "*\/RxSwift\/RxCocoa\/Common\/Binder.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 878
+    }
+  },
+  {
+    "path" : "*\/RxSwift\/RxCocoa\/Common\/Observable+Bind.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1800
+    }
+  },
+  {
+    "path" : "*\/RxSwift\/RxTest\/Schedulers\/TestScheduler.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1970
+    }
+  },
+  {
+    "path" : "*\/Starscream\/Sources\/WebSocket.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Surge\/Sources\/Surge\/FFT.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1789
+    }
+  },
+  {
+    "path" : "*\/Surge\/Sources\/Surge\/Pointers.swift",
+    "modification" : "concurrent-2991",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1582
+    }
+  },
+  {
+    "path" : "*\/SwiftDate\/Sources\/SwiftDate\/DateInRegion\/DateInRegion+Components.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2358
+    }
+  },
+  {
+    "path" : "*\/SwiftDate\/Sources\/SwiftDate\/DateInRegion\/DateInRegion.swift",
+    "modification" : "insideOut-776",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 310,
+      "text" : "', rep_date='"
+    }
+  },
+  {
+    "path" : "*\/SwiftGraph\/Sources\/SwiftGraph\/Search.swift",
+    "modification" : "concurrent-2800",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2193
+    }
+  },
+  {
+    "path" : "*\/SwiftGraph\/Sources\/SwiftGraph\/Search.swift",
+    "modification" : "concurrent-2806",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2582
+    }
+  },
+  {
+    "path" : "*\/SwifterSwift\/Sources\/Extensions\/AppKit\/NSImageExtensions.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 679
+    }
+  },
+  {
+    "path" : "*\/SwiftLint\/Source\/SwiftLintFramework\/Extensions\/Configuration+LintableFiles.swift",
+    "modification" : "insideOut-1111",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 225
+    }
+  },
+  {
+    "path" : "*\/SwiftLint\/Source\/swiftlint\/Extensions\/Configuration+CommandLine.swift",
+    "modification" : "insideOut-100",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 50,
+      "text" : "' ("
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOConcurrencyHelpers\/lock.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOPriorityQueue\/PriorityQueue.swift",
+    "modification" : "concurrent-2857",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2613
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIO\/BaseSocket.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2168
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIO\/ByteBuffer-core.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOEchoServer\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 3688
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOEchoClient\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 3225
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOChatServer\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 7267
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOChatClient\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2542
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOHTTP1\/HTTPDecoder.swift",
+    "modification" : "concurrent-3530",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2284
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOFoundationCompat\/ByteBuffer-foundation.swift",
+    "modification" : "concurrent-3499",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 3488
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOWebSocket\/Base64.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 1913
+    }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOWebSocketServer\/main.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 9947
+    }
+  },
+  {
+    "path" : "*\/SwiftyStoreKit\/SwiftyStoreKit\/InAppReceipt.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9370",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/Then\/Sources\/Then\/Then.swift",
+    "modification" : "concurrent-2136",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 2128
+    }
+  },
+  {
+    "path" : "*\/kommander\/Source\/Dispatcher.swift",
+    "modification" : "concurrent-2809",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 1913
+    }
+  },
+  {
+    "path" : "*\/mapper\/Sources\/Mapper.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-8566",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1650
+    }
+  },
+  {
+    "path" : "*\/panelkit\/PanelKit\/PanelManager\/PanelManager+Pinning.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "codeComplete",
+      "offset" : 2468
+    }
+  },
+  {
+    "path" : "*\/siesta\/Source\/Siesta\/Pipeline\/PipelineProcessing.swift",
+    "modification" : "concurrent-1328",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 845
+    }
+  },
+  {
+    "path" : "*\/vapor_core\/Sources\/Bits\/Byte+Digit.swift",
+    "modification" : "concurrent-280",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 200
+    }
+  },
+  {
+    "path" : "*\/vapor_core\/Sources\/Async\/Deprecated.swift",
+    "modification" : "insideOut-455",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 0
+    }
+  },
+  {
+    "path" : "*\/vapor_core\/Sources\/Core\/CodableReflection\/ReflectionDecodable.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorOpen"
+    }
+  },
+  {
+    "path" : "*\/vapor_database-kit\/Sources\/DatabaseKit\/Database\/DatabaseConfig.swift",
+    "modification" : "insideOut-398",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 58,
+      "text" : "' is already registered."
+    }
+  },
+  {
+    "path" : "*\/vapor_multipart\/Sources\/Multipart\/FormDataDecoder.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1231
+    }
+  },
+  {
+    "path" : "*\/vapor_routing\/Sources\/Routing\/Parameter\/Parameter.swift",
+    "modification" : "concurrent-3003",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 1553
+    }
+  },
+  {
+    "path" : "*\/vapor_service\/Sources\/Service\/Config\/Config.swift",
+    "modification" : "insideOut-211",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 211,
+      "text" : "'."
+    }
+  },
+  {
+    "path" : "*\/vapor_url-encoded-form\/Sources\/URLEncodedForm\/Codable\/URLEncodedFormDecoder.swift",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 2846
+    }
+  },
+  {
+    "path" : "*\/vapor_validation\/Sources\/Validation\/Validations.swift",
+    "modification" : "concurrent-737",
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "request" : {
+      "kind" : "cursorInfo",
+      "offset" : 536
+    }
   },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "NetService/Sources/NetService/Compat.swift",
-    "offset": 77,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18354 (fixed on master; rdar://problem/41217187)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "SemanticRefactoring",
-    "refactoring": "Convert To Trailing Closure",
-    "file": "launchscreensnapshot/LaunchScreenSnapshot/LaunchScreenSnapshot.swift",
-    "offset": 8942,
-    "issue": "https://github.com/apple/swift/pull/17291 (fixed on master; rdar://problem/41093898)"
-  },
-  {
-    "branches": ["master"],
-    "file": "ObjectMapper/Sources/CustomDateFormatTransform.swift",
-    "offset": 1264,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "ObjectMapper/Sources/DictionaryTransform.swift",
-    "offset": 626,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8565"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Perfect/Sources/PerfectLib/Dir.swift",
-    "offset": 2466,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 11,
-    "file": "Plank/Sources/Core/FileGenerator.swift",
-    "offset": 1744,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 11,
-    "file": "ProcedureKit/Sources/ProcedureKit/Any.swift",
-    "offset": 3649,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 11,
-    "file": "ProcedureKit/Sources/ProcedureKitCloud/CloudKit.swift",
-    "offset": 554,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "PromiseKit/Sources/AnyPromise.swift",
-    "offset": 5252,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/18354 (fixed on master; rdar://problem/41217187)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 19,
-    "file": "R.swift/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift",
-    "offset": 675,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "CursorInfo",
-    "file": "Re-Lax/ReLax/ReLax/DataHelpers.swift",
-    "offset": 145,
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Re-Lax/ReLax/ReLax/LCRFlattenedRendition.swift",
-    "offset": 1537,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "ReactiveCocoa/ReactiveCocoa/NSObject+Association.swift",
-    "offset": 3699,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8397"
-  },
-  {
-    "branches": ["master"],
-    "file": "ReactiveCocoa/ReactiveCocoa/AppKit/ActionProxy.swift",
-    "offset": 7,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "ReactiveSwift/Sources/Action.swift",
-    "offset": 5419,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-{
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 26,
-    "file": "Result/Result/Result.swift",
-    "offset": 7559,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "RxSwift/RxSwift/Concurrency/AsyncLock.swift",
-    "offset": 1036,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "failure": "crashed",
-    "length": 18,
-    "file": "RxSwift/RxCocoa/Common/Binder.swift",
-    "offset": 1147,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "RxSwift/RxCocoa/Common/Binder.swift",
-    "offset": 149,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "RxSwift/RxBlocking/BlockingObservable+Operators.swift",
-    "offset": 4157,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "RxSwift/RxTest/Any+Equatable.swift",
-    "offset": 296,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "RxSwift/RxTest/Platform/DeprecationWarner.swift",
-    "offset": 678,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8474"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 29,
-    "file": "Serpent/Sources/BridgingBox.swift",
-    "offset": 1015,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "Sourcery/Sources/SourceryRuntime/Diffable.swift",
-    "offset": 3072,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Starscream/Sources/SSLSecurity.swift",
-    "offset": 2600,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8556"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 15,
-    "file": "Starscream/Sources/WebSocket.swift",
-    "offset": 26364,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 12,
-    "file": "SwiftDate/Sources/DateRepresentable.swift",
-    "offset": 17648,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 14,
-    "file": "SwiftGraph/Sources/SwiftGraph/Cycle.swift",
-    "offset": 3256,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "SwiftLint/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift",
-    "offset": 797,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 26,
-    "file": "SwiftLint/Source/swiftlint/Commands/GenerateDocsCommand.swift",
-    "offset": 702,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "SwifterSwift/Sources/Extensions/AppKit/NSImageExtensions.swift",
-    "offset": 138,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOConcurrencyHelpers/lock.swift",
-    "offset": 2633,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIO/BaseSocket.swift",
-    "offset": 1226,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIO/BaseSocket.swift",
-    "offset": 13934,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOEchoServer/main.swift",
-    "offset": 2692,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOChatClient/main.swift",
-    "offset": 1522,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOEchoClient/main.swift",
-    "offset": 2200,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOChatServer/main.swift",
-    "offset": 6295,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOHTTP1/HTTPDecoder.swift",
-    "offset": 2212,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOHTTP1Server/main.swift",
-    "offset": 23695,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOPerformanceTester/main.swift",
-    "offset": 4028,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "swift-nio/Sources/NIOWebSocketServer/main.swift",
-    "offset": 8969,
-    "request": "CursorInfo",
-    "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 30,
-    "file": "SwiftyStoreKit/SwiftyStoreKit/CompleteTransactionsController.swift",
-    "offset": 2818,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "SwiftyStoreKit/SwiftyStoreKit/AppleReceiptValidator.swift",
-    "offset": 2402,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "URBNJSONDecodableSPM/Sources/JSONDecodable.swift",
-    "offset": 3635,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/commit/398abdfb (fixed on master; rdar://problem/41175473)"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "SemanticRefactoring",
-    "refactoring": "Local Rename",
-    "file": "mapper/Sources/Mapper.swift",
-    "offset": 1650,
-    "issue": "https://bugs.swift.org/browse/SR-8566"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "request": "RangeInfo",
-    "length": 24,
-    "file": "panelkit/PanelKit/Controller/PanelViewController+Dragging.swift",
-    "offset": 379,
-    "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "siesta/Source/Siesta/Configuration.swift",
-    "offset": 148,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8553"
-  },
-  {
-    "branches": ["swift-4.2-branch"],
-    "file": "siesta/Source/Siesta/Entity.swift",
-    "offset": 7210,
-    "request": "CodeComplete",
-    "issue": "https://github.com/apple/swift/pull/17339 (fixed on master; rdar://problem/41219750)"
-  }
 ]

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1,17 +1,10 @@
 [
   {
     "branches": ["master"],
-    "file": "AMScrollingNavbar/Source/ScrollingNavbar+Sizes.swift",
-    "offset": 191,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
     "file": "Alamofire/Source/AFError.swift",
-    "offset": 8221,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
+    "offset": 2817,
+    "request": "CursorInfo",
+    "issue": "https://bugs.swift.org/browse/SR-8812"
   },
   {
     "branches": ["swift-4.2-branch"],
@@ -30,33 +23,17 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "AsyncNinja/Sources/BaseProducer.swift",
     "offset": 1773,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
-    "branches": ["master"],
-    "file": "BlueSocket/Sources/Socket.swift",
-    "offset": 10012,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "BlueSocket/Sources/Socket.swift",
     "offset": 30861,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Chatto/Chatto/Source/Chat Items/BaseChatItemPresenter.swift",
-    "offset": 2550,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
   },
   {
     "branches": ["master"],
@@ -68,7 +45,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 12,
     "file": "Chatto/Chatto/Source/Chat Items/ChatItemCompanion.swift",
     "offset": 1580,
@@ -77,41 +53,22 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 34,
     "file": "Chatto/ChattoAdditions/Source/Chat Items/BaseMessage/Views/BaseMessageCollectionViewCell.swift",
     "offset": 8369,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "CleanroomLogger/Sources/BasicLogConfiguration.swift",
-    "offset": 3132,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 8,
     "file": "CleanroomLogger/Sources/ConcatenatingLogFormatter.swift",
     "offset": 2348,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "CoreStore/Sources/AsynchronousDataTransaction.swift",
-    "offset": 2119,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 22,
     "file": "CoreStore/Sources/CSDataStack+Observing.swift",
     "offset": 3048,
@@ -120,26 +77,10 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 13,
     "file": "cub/Sources/Cub/AST/Nodes/ArrayNode.swift",
     "offset": 758,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "cub/Sources/Cub/AST/ASTNode+Validation.swift",
-    "offset": 198,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
-    "request": "CursorInfo",
-    "failure": "crashed",
-    "file": "DNS/Sources/DNS/Bytes.swift",
-    "offset": 2565,
-    "issue": "https://bugs.swift.org/browse/SR-8559"
   },
   {
     "branches": ["swift-4.2-branch"],
@@ -153,7 +94,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 24,
     "file": "Deferred/Sources/Deferred/Deferred.swift",
     "offset": 2331,
@@ -161,25 +101,10 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Deferred/Sources/Task/TaskAndThen.swift",
     "offset": 2614,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Dollar/Sources/Dollar.swift",
-    "offset": 5214,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "Dwifft/Dwifft/Dwifft+UIKit.swift",
-    "offset": 1541,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
   },
   {
     "branches": ["master"],
@@ -191,7 +116,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 18,
     "file": "Evergreen/submodules/RSCore/RSCore/RSToolbarItem.swift",
     "offset": 1174,
@@ -199,7 +123,6 @@
   },
   {
     "branches": ["master"],
-    "failure": "crashed",
     "file": "Evergreen/submodules/RSParser/Sources/Feeds/FeedType.swift",
     "offset": 705,
     "request": "CursorInfo",
@@ -208,7 +131,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 17,
     "file": "Evergreen/submodules/RSDatabase/RSDatabase/DatabaseObject.swift",
     "offset": 649,
@@ -217,18 +139,10 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 24,
     "file": "Evergreen/submodules/RSWeb/RSWeb/DownloadSession.swift",
     "offset": 3145,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
-  },
-  {
-    "branches": ["master"],
-    "file": "Evergreen/submodules/RSDatabase/RSDatabase/DatabaseTable.swift",
-    "offset": 2528,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
   },
   {
     "branches": ["master"],
@@ -246,7 +160,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Evergreen/Frameworks/Data/DatabaseID.swift",
     "offset": 488,
     "request": "CursorInfo",
@@ -283,7 +196,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 24,
     "file": "Evergreen/Frameworks/Account/Account.swift",
     "offset": 2653,
@@ -292,7 +204,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 20,
     "file": "Evergreen/Commands/DeleteFromSidebarCommand.swift",
     "offset": 2831,
@@ -300,7 +211,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "request": "SemanticRefactoring",
     "refactoring": "Convert To Trailing Closure",
     "file": "exercism-*swift/exercises/word-count/Sources/WordCountExample.swift",
@@ -309,7 +219,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "exercism-*swift/exercises/acronym/Sources/AcronymExample.swift",
     "offset": 913,
     "request": "CursorInfo",
@@ -317,7 +226,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "fluent/Sources/Fluent/Cache/CacheEntry.swift",
     "offset": 534,
     "request": "CodeComplete",
@@ -325,7 +233,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "fluent/Sources/FluentBenchmark/Benchmarks/Bar.swift",
     "offset": 240,
     "request": "CodeComplete",
@@ -333,7 +240,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "GRDB.swift/GRDB/Core/Cursor.swift",
     "offset": 22555,
     "request": "CursorInfo",
@@ -341,7 +247,6 @@
   },
   {
     "branches": ["master"],
-    "failure": "crashed",
     "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallBeat.swift",
     "offset": 2007,
     "request": "CursorInfo",
@@ -349,77 +254,35 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "IBAnimatable/Sources/ActivityIndicators/Animations/ActivityIndicatorAnimationBallPulseRise.swift",
     "offset": 2460,
     "request": "CodeComplete",
     "issue": "https://github.com/apple/swift/pull/18665 (fixed on master; rdar://problem/42639255)"
   },
   {
-    "branches": ["master"],
-    "file": "JSQCoreDataKit/Source/CoreDataEntityProtocol.swift",
-    "offset": 853,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
-    "file": "JSQDataSourcesKit/Source/BridgedDataSource.swift",
-    "offset": 3924,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "JSQDataSourcesKit/Source/ReusableViewConfig.swift",
     "offset": 6930,
     "request": "CodeComplete",
     "issue": "https://github.com/apple/swift/commit/398abdfb (fixed on master; rdar://problem/41175473)"
   },
   {
-    "branches": ["master"],
-    "file": "KeychainAccess/Lib/KeychainAccess/Keychain.swift",
-    "offset": 8251,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 26,
     "file": "KeychainAccess/Lib/KeychainAccess/Keychain.swift",
     "offset": 18237,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "request": "CursorInfo",
-    "failure": "crashed",
-    "file": "Kickstarter-Prelude/Prelude/Array.swift",
-    "offset": 2127,
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Kickstarter-Prelude/Prelude/Optional.swift",
     "offset": 1585,
     "request": "CodeComplete",
     "issue": "https://github.com/apple/swift/pull/17339 (fixed on master; rdar://problem/41219750)"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "Kickstarter-Prelude/Prelude-UIKit/UIButton.swift",
-    "offset": 339,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Kickstarter-Prelude/Prelude-UIKit/UIImage.swift",
     "offset": 309,
     "request": "CursorInfo",
@@ -427,7 +290,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Kickstarter-ReactiveExtensions/Frameworks/ReactiveSwift/Sources/Action.swift",
     "offset": 3959,
     "request": "CodeComplete",
@@ -442,7 +304,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Kingfisher/Sources/Image.swift",
     "offset": 21272,
     "request": "CursorInfo",
@@ -450,7 +311,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "failed",
     "request": "SemanticRefactoring",
     "refactoring": "Local Rename",
     "file": "Kitura/Sources/Kitura/CodableRouter.swift",
@@ -458,23 +318,7 @@
     "issue": "https://bugs.swift.org/browse/SR-8566"
   },
   {
-    "branches": ["master"],
-    "request": "CursorInfo",
-    "failure": "crashed",
-    "file": "Kitura/Sources/Kitura/CodableRouter+TypeSafeMiddleware.swift",
-    "offset": 2343,
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["master"],
-    "file": "Kronos/Sources/Clock.swift",
-    "offset": 2593,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Kronos/Sources/DNSResolver.swift",
     "offset": 3012,
     "request": "CursorInfo",
@@ -483,7 +327,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 16,
     "file": "Lark/Sources/Lark/Client.swift",
     "offset": 6608,
@@ -492,7 +335,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 9,
     "file": "Lark/Sources/CodeGenerator/Generator.swift",
     "offset": 5239,
@@ -501,7 +343,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 16,
     "file": "Moya/Sources/Moya/AnyEncodable.swift",
     "offset": 233,
@@ -509,7 +350,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Moya/Sources/ReactiveMoya/MoyaProvider+Reactive.swift",
     "offset": 382,
     "request": "CodeComplete",
@@ -517,7 +357,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Moya/Sources/RxMoya/MoyaProvider+Rx.swift",
     "offset": 1536,
     "request": "CodeComplete",
@@ -525,7 +364,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "NetService/Sources/NetService/Compat.swift",
     "offset": 77,
     "request": "CodeComplete",
@@ -534,7 +372,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "SemanticRefactoring",
-    "failure": "crashed",
     "refactoring": "Convert To Trailing Closure",
     "file": "launchscreensnapshot/LaunchScreenSnapshot/LaunchScreenSnapshot.swift",
     "offset": 8942,
@@ -549,7 +386,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "ObjectMapper/Sources/DictionaryTransform.swift",
     "offset": 626,
     "request": "CodeComplete",
@@ -557,40 +393,22 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Perfect/Sources/PerfectLib/Dir.swift",
     "offset": 2466,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
-    "branches": ["master"],
-    "file": "PinkyPromise/Sources/Promise.swift",
-    "offset": 11120,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 11,
     "file": "Plank/Sources/Core/FileGenerator.swift",
     "offset": 1744,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "ProcedureKit/Sources/ProcedureKit/Any.swift",
-    "offset": 1387,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 11,
     "file": "ProcedureKit/Sources/ProcedureKit/Any.swift",
     "offset": 3649,
@@ -599,30 +417,13 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 11,
     "file": "ProcedureKit/Sources/ProcedureKitCloud/CloudKit.swift",
     "offset": 554,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "file": "ProcedureKit/Sources/ProcedureKitCloud/CKAcceptSharesOperation.swift",
-    "offset": 1217,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "PromiseKit/Sources/AnyPromise.swift",
-    "offset": 5184,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "PromiseKit/Sources/AnyPromise.swift",
     "offset": 5252,
     "request": "CodeComplete",
@@ -631,7 +432,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 19,
     "file": "R.swift/Sources/RswiftCore/Generators/AggregatedStructGenerator.swift",
     "offset": 675,
@@ -640,36 +440,25 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "CursorInfo",
-    "failure": "crashed",
     "file": "Re-Lax/ReLax/ReLax/DataHelpers.swift",
     "offset": 145,
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
     "branches": ["master"],
-    "failure": "crashed",
     "file": "Re-Lax/ReLax/ReLax/LCRFlattenedRendition.swift",
     "offset": 1537,
     "request": "CursorInfo",
     "issue": "https://bugs.swift.org/browse/SR-8559"
   },
   {
-    "branches": ["master"],
-    "file": "ReSwift/ReSwift/CoreTypes/Action.swift",
-    "offset": 2037,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "ReactiveCocoa/ReactiveCocoa/NSObject+Association.swift",
     "offset": 3699,
     "request": "CodeComplete",
     "issue": "https://bugs.swift.org/browse/SR-8397"
   },
   {
-    "failure": "crashed",
     "branches": ["master"],
     "file": "ReactiveCocoa/ReactiveCocoa/AppKit/ActionProxy.swift",
     "offset": 7,
@@ -677,16 +466,7 @@
     "issue": "https://bugs.swift.org/browse/SR-8553"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "ReactiveSwift/Sources/Action.swift",
-    "offset": 4431,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "ReactiveSwift/Sources/Action.swift",
     "offset": 5419,
     "request": "CursorInfo",
@@ -695,7 +475,6 @@
 {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 26,
     "file": "Result/Result/Result.swift",
     "offset": 7559,
@@ -703,19 +482,10 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "RxSwift/RxSwift/Concurrency/AsyncLock.swift",
     "offset": 1036,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
-  },
-  {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "RxSwift/Platform/DispatchQueue+Extensions.swift",
-    "offset": 329,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
   },
   {
     "branches": ["swift-4.2-branch"],
@@ -734,15 +504,7 @@
     "issue": "https://bugs.swift.org/browse/SR-8553"
   },
   {
-    "branches": ["master"],
-    "file": "RxSwift/RxBlocking/BlockingObservable+Operators.swift",
-    "offset": 3131,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "RxSwift/RxBlocking/BlockingObservable+Operators.swift",
     "offset": 4157,
     "request": "CursorInfo",
@@ -757,23 +519,14 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "RxSwift/RxTest/Platform/DeprecationWarner.swift",
     "offset": 678,
     "request": "CodeComplete",
     "issue": "https://bugs.swift.org/browse/SR-8474"
   },
   {
-    "branches": ["master"],
-    "file": "SRP/Sources/AuthenticationFailure.swift",
-    "offset": 700,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 29,
     "file": "Serpent/Sources/BridgingBox.swift",
     "offset": 1015,
@@ -781,7 +534,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "Sourcery/Sources/SourceryRuntime/Diffable.swift",
     "offset": 3072,
     "request": "CursorInfo",
@@ -797,48 +549,22 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 15,
     "file": "Starscream/Sources/WebSocket.swift",
     "offset": 26364,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "file": "Surge/Source/Matrix.swift",
-    "offset": 3657,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "SwiftDate/Sources/DateRepresentable.swift",
-    "offset": 11081,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 12,
     "file": "SwiftDate/Sources/DateRepresentable.swift",
     "offset": 17648,
     "issue": "https://github.com/apple/swift/pull/18284 (fixed on master; rdar://problem/41147733)"
   },
   {
-    "branches": ["master"],
-    "request": "CursorInfo",
-    "failure": "crashed",
-    "file": "SwiftGraph/Sources/SwiftGraph/Cycle.swift",
-    "offset": 1388,
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 14,
     "file": "SwiftGraph/Sources/SwiftGraph/Cycle.swift",
     "offset": 3256,
@@ -846,7 +572,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "SwiftLint/Source/SwiftLintFramework/Extensions/Configuration+Cache.swift",
     "offset": 797,
     "request": "CursorInfo",
@@ -855,7 +580,6 @@
   {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 26,
     "file": "SwiftLint/Source/swiftlint/Commands/GenerateDocsCommand.swift",
     "offset": 702,
@@ -869,22 +593,7 @@
     "issue": "https://bugs.swift.org/browse/SR-8553"
   },
   {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOConcurrencyHelpers/atomics.swift",
-    "offset": 15907,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8554"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOPriorityQueue/Heap.swift",
-    "offset": 4260,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOConcurrencyHelpers/lock.swift",
     "offset": 2633,
     "request": "CursorInfo",
@@ -892,7 +601,6 @@
   },
   {
     "branches": ["master"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIO/BaseSocket.swift",
     "offset": 1226,
     "request": "CursorInfo",
@@ -900,7 +608,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIO/BaseSocket.swift",
     "offset": 13934,
     "request": "CursorInfo",
@@ -908,7 +615,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOEchoServer/main.swift",
     "offset": 2692,
     "request": "CursorInfo",
@@ -916,7 +622,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOChatClient/main.swift",
     "offset": 1522,
     "request": "CursorInfo",
@@ -924,7 +629,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOEchoClient/main.swift",
     "offset": 2200,
     "request": "CursorInfo",
@@ -932,87 +636,20 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOChatServer/main.swift",
     "offset": 6295,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOChatClient/main.swift",
-    "offset": 815,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOFoundationCompat/ByteBuffer-foundation.swift",
-    "offset": 4172,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOChatServer/main.swift",
-    "offset": 1051,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOTLS/ApplicationProtocolNegotiationHandler.swift",
-    "offset": 4010,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOHTTP1/HTTPDecoder.swift",
     "offset": 2212,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "swift-nio/Sources/NIOHTTP1/HTTPDecoder.swift",
-    "offset": 8123,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOHTTP1Server/main.swift",
-    "offset": 7812,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOWebSocket/Base64.swift",
-    "offset": 1773,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOPerformanceTester/main.swift",
-    "offset": 2824,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "swift-nio/Sources/NIOWebSocketServer/main.swift",
-    "offset": 2037,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOHTTP1Server/main.swift",
     "offset": 23695,
     "request": "CursorInfo",
@@ -1020,7 +657,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOPerformanceTester/main.swift",
     "offset": 4028,
     "request": "CursorInfo",
@@ -1028,37 +664,14 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "swift-nio/Sources/NIOWebSocketServer/main.swift",
     "offset": 8969,
     "request": "CursorInfo",
     "issue": "https://github.com/apple/swift/pull/18198 (fixed on master; rdar://problem/41100570)"
   },
   {
-    "branches": ["master"],
-    "file": "kommander/Source/CurrentDispatcher.swift",
-    "offset": 416,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "launchscreensnapshot/LaunchScreenSnapshot/LaunchScreenSnapshot.swift",
-    "offset": 7191,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
-    "branches": ["master"],
-    "file": "mapper/Sources/DefaultConvertible.swift",
-    "offset": 754,
-    "request": "CodeComplete",
-    "issue": "https://bugs.swift.org/browse/SR-8555"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 30,
     "file": "SwiftyStoreKit/SwiftyStoreKit/CompleteTransactionsController.swift",
     "offset": 2818,
@@ -1073,7 +686,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "URBNJSONDecodableSPM/Sources/JSONDecodable.swift",
     "offset": 3635,
     "request": "CodeComplete",
@@ -1081,7 +693,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "failed",
     "request": "SemanticRefactoring",
     "refactoring": "Local Rename",
     "file": "mapper/Sources/Mapper.swift",
@@ -1089,17 +700,8 @@
     "issue": "https://bugs.swift.org/browse/SR-8566"
   },
   {
-    "branches": ["master"],
-    "failure": "crashed",
-    "file": "panelkit/PanelKit/Controller/PanelNavigationController.swift",
-    "offset": 629,
-    "request": "CursorInfo",
-    "issue": "https://bugs.swift.org/browse/SR-8559"
-  },
-  {
     "branches": ["swift-4.2-branch"],
     "request": "RangeInfo",
-    "failure": "crashed",
     "length": 24,
     "file": "panelkit/PanelKit/Controller/PanelViewController+Dragging.swift",
     "offset": 379,
@@ -1114,7 +716,6 @@
   },
   {
     "branches": ["swift-4.2-branch"],
-    "failure": "crashed",
     "file": "siesta/Source/Siesta/Entity.swift",
     "offset": 7210,
     "request": "CodeComplete",


### PR DESCRIPTION
Updates the `run_sk_stress_test` script for various  SourceKit stress tester and SwiftSyntax build and functionality changes:
- update script to account for swift-syntax now being in its own repo, rather than swift's
- xfail tracking is now handled by the stress tester itself, so remove it from the script, and update the xfails file for the new format.
- Update the xfails file with the latest issues (from a full run over the weekend).
- The SourceKit stress tester build is now handled by Swift's build-script so stop building it separately and update the build-script invocation for the toolchain with the new flags.
- Refine the set of projects with the `sourcekit-smoke` tag (due to various new checks in the stress tester, the previous set started taking too long).
- Remove the `sourcekit` and `sourcekit-smoke` tags on all but one of the various platform-specific actions in Surge (there's not much difference from SourceKit's perspective, so it's not worth the time cost of testing more than one).
