### PR TITLE
Restore vapor_routing xfail

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3109,7 +3109,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail" : {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9505"
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
It was un-xfailed as part of reverting the Result xfails, but its underlying issue (https://bugs.swift.org/browse/SR-9505) is different and still a problem.