### PR TITLE
Update swift-5.0-branch xfails

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1185,7 +1185,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8234"
+                "master": "https://bugs.swift.org/browse/SR-8234",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8234"
               }
             }
           }
@@ -2132,7 +2133,8 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "rdar://46189034"
+                "master": "https://bugs.swift.org/browse/SR-9543",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9543"
               }
             }
           }
@@ -2401,12 +2403,14 @@
           "compatibility": {
             "4.0": {
               "branch": {
-                "master": "rdar://46189034"
+                "master": "https://bugs.swift.org/browse/SR-9543",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9543"
               }
             },
             "4.2": {
               "branch": {
-                "master": "rdar://46189034"
+                "master": "https://bugs.swift.org/browse/SR-9543",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9543"
               }
             }
           }

--- a/projects.json
+++ b/projects.json
@@ -3114,7 +3114,8 @@
           "compatibility": {
             "4.2": {
               "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9505"
+                "master": "https://bugs.swift.org/browse/SR-9505",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9505"
               }
             }
           }


### PR DESCRIPTION
Adding Xfails for current failures:
   FAIL: Lark, 4.0, 7604f9, Swift Package -> https://bugs.swift.org/browse/SR-8234
   FAIL: SRP, 4.0, b16683, Swift Package -> https://bugs.swift.org/browse/SR-9543
   FAIL: SwiftLint, 4.2, 60f98e, Swift Package -> https://bugs.swift.org/browse/SR-9543
   FAIL: SwiftLint, 4.0, 60f98e, Swift Package -> https://bugs.swift.org/browse/SR-9543
   FAIL: vapor_routing, 4.2, 3219e3, Swift Package -> https://bugs.swift.org/browse/SR-9505
 