### PR TITLE
[run_sk_stress_test] Reduce the set of projects to test and update the summary output

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2275,7 +2275,7 @@
         "scheme": "Surge-macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -264,7 +264,8 @@ class StressTesterRunner(object):
             results = json.load(results_file)
 
         num_failures = len(results['failures'])
-        num_xfails = len(results['expectedFailures'])
+        num_xfails = sum(len(value) for _, value in results['expectedFailures'].iteritems())
+        num_xfail_issues = len(results['expectedFailures'])
         unmatched = results['unmatchedExpectedFailures']
 
         success = num_failures == 0 and len(unmatched) == 0
@@ -279,7 +280,7 @@ class StressTesterRunner(object):
         if num_failures > 0:
             print('      > search "Detected unexpected failure:" for individual failures')
 
-        print('  {} expected stress tester failures'.format(num_xfails))
+        print('  {} expected stress tester failures tracked by {} issues'.format(num_xfails, num_xfail_issues))
 
         if not self.compat_runner_failed and unmatched:
             print('  {} expected stress tester failures not seen'.format(len(unmatched)))


### PR DESCRIPTION
Remove Surge from the set of 'sourcekit-smoke' projects and fix the number of failures reported in the summary output to reflect the number of individual failures in addition to the number of unique issue urls they're associated with.