### PR TITLE
Fix bug in compiler performance test script

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -134,18 +134,6 @@ def main():
             execute_runner(instance, workspace, configs, args)
 
     regressions = analyze_results(configs, args)
-
-    # Crude hack to write output to workspace when in CI,
-    # regardless of --output passed.
-    if ws_comment is not None:
-        out = os.path.abspath(os.path.join(os.getcwd(),
-                                           args.output.name))
-        print("Output written to: %s" % out)
-        if out != ws_comment:
-            print("Copying %s to %s" % (out, ws_comment))
-            args.output.close()
-            shutil.copyfile(out, ws_comment)
-
     return regressions
 
 


### PR DESCRIPTION
Commit 6952162 (which seems to have been pushed directly to master) appears to have inadvertently fixed a prior bug in the run_cperf script which was causing it to save its output file in the wrong place. Unfortunately, it also broke the hack which was copying the file to the *right* place, causing all compiler performance tests to raise an error right before the comment with the results was posted to Github.

This PR removes the hack, which I believe will at least partially fix compiler performance tests. We may still need to XFAIL a few projects or something, but we should at least get the comment now.

Tagging @shahmishal, because I'm hoping there's a way to test this on the CI before merging it, and if there is I think he'll know how to do it.