### PR TITLE
Add Swift 5.0 config for source compat projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -13,6 +13,10 @@
       {
         "version": "4.2",
         "commit": "8bfcc8b881634c97d0b46705f0ba43f692ad8644"
+      },
+      {
+        "version": "5.0",
+        "commit": "8bfcc8b881634c97d0b46705f0ba43f692ad8644"
       }
     ],
     "platforms": [
@@ -199,6 +203,10 @@
       {
         "version": "4.2",
         "commit": "fb4e74cd8eb3ce4a2b860fbf727b2dada796d77d"
+      },
+      {
+        "version": "5.0",
+        "commit": "fb4e74cd8eb3ce4a2b860fbf727b2dada796d77d"
       }
     ],
     "platforms": [
@@ -347,6 +355,10 @@
       {
         "version": "4.2",
         "commit": "2863605d845cd9bb255ddd91f47f92717dec637f"
+      },
+      {
+        "version": "5.0",
+        "commit": "2863605d845cd9bb255ddd91f47f92717dec637f"
       }
     ],
     "platforms": [
@@ -358,7 +370,17 @@
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -366,21 +388,51 @@
         "scheme": "CoreStore OSX",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestXcodeWorkspaceScheme",
@@ -476,6 +528,10 @@
       {
         "version": "4.2",
         "commit": "c374a6e7072ed88ed0c79299098ca2ba7c27e720"
+      },
+      {
+        "version": "5.0",
+        "commit": "c374a6e7072ed88ed0c79299098ca2ba7c27e720"
       }
     ],
     "platforms": [
@@ -494,21 +550,51 @@
         "project": "Deferred.xcodeproj",
         "scheme": "MobileDeferred",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "Deferred.xcodeproj",
         "scheme": "TVDeferred",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "Deferred.xcodeproj",
         "scheme": "NanoDeferred",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -604,6 +690,10 @@
       {
         "version": "4.2",
         "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
+      },
+      {
+        "version": "5.0",
+        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
       }
     ],
     "platforms": [
@@ -618,6 +708,12 @@
         "xfail": {
           "compatibility": {
             "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8307",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307"
+              }
+            },
+            "5.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-8307",
                 "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307"
@@ -686,6 +782,10 @@
       {
         "version": "4.2",
         "commit": "270b6fa372f03809b9795e8f8b9d1c31267a0ff3"
+      },
+      {
+        "version": "5.0",
+        "commit": "270b6fa372f03809b9795e8f8b9d1c31267a0ff3"
       }
     ],
     "platforms": [
@@ -707,6 +807,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
+      },
+      {
+        "version": "5.0",
         "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
       }
     ],
@@ -733,6 +837,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "c0e68b17c6741e32b131ab33bbdd33524027e2af"
+      },
+      {
+        "version": "5.0",
         "commit": "c0e68b17c6741e32b131ab33bbdd33524027e2af"
       }
     ],
@@ -771,6 +879,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "e6952b9246dd9bf27d613ed7b4791ff19136f6c8"
+      },
+      {
+        "version": "5.0",
         "commit": "e6952b9246dd9bf27d613ed7b4791ff19136f6c8"
       }
     ],
@@ -830,6 +942,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "e651887d0a621c6b66ca09c2e8cea9fce691c00e"
+      },
+      {
+        "version": "5.0",
         "commit": "e651887d0a621c6b66ca09c2e8cea9fce691c00e"
       }
     ],
@@ -894,6 +1010,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "0fffcc37adcf55d3557f1e06dd0172ace582effe"
+      },
+      {
+        "version": "5.0",
         "commit": "0fffcc37adcf55d3557f1e06dd0172ace582effe"
       }
     ],
@@ -1104,6 +1224,10 @@
       {
         "version": "4.2",
         "commit": "d38491d123fb58897ecb339920cf69da479d19d0"
+      },
+      {
+        "version": "5.0",
+        "commit": "d38491d123fb58897ecb339920cf69da479d19d0"
       }
     ],
     "platforms": [
@@ -1194,6 +1318,10 @@
       {
         "version": "4.2",
         "commit": "d8bb2bc535e2895b5fbe66f4872327b654d19a34"
+      },
+      {
+        "version": "5.0",
+        "commit": "d8bb2bc535e2895b5fbe66f4872327b654d19a34"
       }
     ],
     "platforms": [
@@ -1218,6 +1346,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "e880839b9185a33acb8683413a89cca44d1955ef"
+      },
+      {
+        "version": "5.0",
         "commit": "e880839b9185a33acb8683413a89cca44d1955ef"
       }
     ],
@@ -1279,6 +1411,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "927eb171a738266b9b98fc6ca0506fb95f241b05"
+      },
+      {
+        "version": "5.0",
         "commit": "927eb171a738266b9b98fc6ca0506fb95f241b05"
       }
     ],
@@ -1361,6 +1497,10 @@
       {
         "version": "4.2",
         "commit": "ed1caa237b9742135996fefe3682b834bb394a6a"
+      },
+      {
+        "version": "5.0",
+        "commit": "ed1caa237b9742135996fefe3682b834bb394a6a"
       }
     ],
     "platforms": [
@@ -1407,6 +1547,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "1632b5dd5862bb2d377be79d5063d2161a7559e5"
+      },
+      {
+        "version": "5.0",
         "commit": "1632b5dd5862bb2d377be79d5063d2161a7559e5"
       }
     ],
@@ -1462,6 +1606,10 @@
       {
         "version": "4.2",
         "commit": "cdc17d544ec8e87da5f3b24cdbda8d02d77bb943"
+      },
+      {
+        "version": "5.0",
+        "commit": "cdc17d544ec8e87da5f3b24cdbda8d02d77bb943"
       }
     ],
     "platforms": [
@@ -1484,6 +1632,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "5c15634de4ff3152e9ccede6543c83ed93e2cf7b"
+      },
+      {
+        "version": "5.0",
         "commit": "5c15634de4ff3152e9ccede6543c83ed93e2cf7b"
       }
     ],
@@ -1513,6 +1665,12 @@
         "xfail": {
           "compatibility": {
             "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8250",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8250"
+              }
+            },
+            "5.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-8250",
                 "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8250"
@@ -1549,6 +1707,10 @@
       {
         "version": "4.2",
         "commit": "71a3a5ce5e38161eaf4e46a7f609f2e4523d8248"
+      },
+      {
+        "version": "5.0",
+        "commit": "71a3a5ce5e38161eaf4e46a7f609f2e4523d8248"
       }
     ],
     "maintainer": "rmalik@pinterest.com",
@@ -1577,6 +1739,10 @@
       {
         "version": "4.2",
         "commit": "94193d59bc06689526772023428402da1e0e299f"
+      },
+      {
+        "version": "5.0",
+        "commit": "94193d59bc06689526772023428402da1e0e299f"
       }
     ],
     "platforms": [
@@ -1589,14 +1755,34 @@
         "target": "ProcedureKit",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1610,7 +1796,17 @@
         "project": "ProcedureKit.xcodeproj",
         "target": "ProcedureKit",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -1618,7 +1814,17 @@
         "target": "ProcedureKitCloud",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-9899",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestXcodeProjectTarget",
@@ -1686,6 +1892,10 @@
       {
         "version": "4.2",
         "commit": "f96758593573d3d1d9ae8084721033ab0bf392f6"
+      },
+      {
+        "version": "5.0",
+        "commit": "f96758593573d3d1d9ae8084721033ab0bf392f6"
       }
     ],
     "platforms": [
@@ -1737,6 +1947,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "beeb3c6368d573980a703ea37ab58e01f2a825c5"
+      },
+      {
+        "version": "5.0",
         "commit": "beeb3c6368d573980a703ea37ab58e01f2a825c5"
       }
     ],
@@ -1879,6 +2093,10 @@
       {
         "version": "4.2",
         "commit": "2fe5b325a8a54e77c545b2f511213420da133b8c"
+      },
+      {
+        "version": "5.0",
+        "commit": "2fe5b325a8a54e77c545b2f511213420da133b8c"
       }
     ],
     "maintainer": "matt@diephouse.com",
@@ -1906,6 +2124,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "5458733cb4d2a1ca6a457804921a5fac4b72fca2"
+      },
+      {
+        "version": "5.0",
         "commit": "5458733cb4d2a1ca6a457804921a5fac4b72fca2"
       }
     ],
@@ -2082,6 +2304,10 @@
       {
         "version": "4.2",
         "commit": "33ce18293ef42e5565ce285a15ee70ac9d5b121d"
+      },
+      {
+        "version": "5.0",
+        "commit": "33ce18293ef42e5565ce285a15ee70ac9d5b121d"
       }
     ],
     "platforms": [
@@ -2096,6 +2322,12 @@
         "xfail": {
           "compatibility": {
             "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-8250",
+                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8250"
+              }
+            },
+            "5.0": {
               "branch": {
                 "master": "https://bugs.swift.org/browse/SR-8250",
                 "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8250"
@@ -2192,6 +2424,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "38a328eefe5ffef13d28dcb2804d2772aecf6107"
+      },
+      {
+        "version": "5.0",
         "commit": "38a328eefe5ffef13d28dcb2804d2772aecf6107"
       }
     ],
@@ -2314,6 +2550,10 @@
       {
         "version": "4.2",
         "commit": "60f98ec50d74c6e6aa7c527493d844960653f3a6"
+      },
+      {
+        "version": "5.0",
+        "commit": "60f98ec50d74c6e6aa7c527493d844960653f3a6"
       }
     ],
     "maintainer": "jp@jpsim.com",
@@ -2407,6 +2647,10 @@
       {
         "version": "4.2",
         "commit": "e56d1cc41c51badcadcdff825484bf61bc48f418"
+      },
+      {
+        "version": "5.0",
+        "commit": "e56d1cc41c51badcadcdff825484bf61bc48f418"
       }
     ],
     "platforms": [
@@ -2432,6 +2676,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "b93c5d2bd883959262b4c7aabe333667dadb1ab0"
+      },
+      {
+        "version": "5.0",
         "commit": "b93c5d2bd883959262b4c7aabe333667dadb1ab0"
       }
     ],
@@ -2641,6 +2889,10 @@
       {
         "version": "4.2",
         "commit": "3edb1c0f557506d845362fda6d8564718435bfb1"
+      },
+      {
+        "version": "5.0",
+        "commit": "3edb1c0f557506d845362fda6d8564718435bfb1"
       }
     ],
     "platforms": [
@@ -2699,6 +2951,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "03555e5e2a517f977ba8736172115f0db2c645a8"
+      },
+      {
+        "version": "5.0",
         "commit": "03555e5e2a517f977ba8736172115f0db2c645a8"
       }
     ],
@@ -2776,6 +3032,10 @@
       },
       {
         "version": "4.2",
+        "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
+      },
+      {
+        "version": "5.0",
         "commit": "d501cb83be55d67779dd2dc3e2dea53fdf78c39d"
       }
     ],
@@ -2918,6 +3178,10 @@
       {
         "version": "4.2",
         "commit": "5b9796d39f201b3dd06800437abd9d774a455e57"
+      },
+      {
+        "version": "5.0",
+        "commit": "5b9796d39f201b3dd06800437abd9d774a455e57"
       }
     ],
     "platforms": [
@@ -2941,6 +3205,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "08a5764af95ccf0a08d0a510358c18628736070d"
+      },
+      {
+        "version": "5.0",
         "commit": "08a5764af95ccf0a08d0a510358c18628736070d"
       }
     ],
@@ -2966,6 +3234,10 @@
       {
         "version": "4.2",
         "commit": "3a17dbbe9be5f8c37703e4b7982c1332ad6b00c4"
+      },
+      {
+        "version": "5.0",
+        "commit": "3a17dbbe9be5f8c37703e4b7982c1332ad6b00c4"
       }
     ],
     "platforms": [
@@ -2989,6 +3261,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "e57007c23a52b68e44ebdfc70cbe882a7c4f1ec3"
+      },
+      {
+        "version": "5.0",
         "commit": "e57007c23a52b68e44ebdfc70cbe882a7c4f1ec3"
       }
     ],
@@ -3014,6 +3290,10 @@
       {
         "version": "4.2",
         "commit": "3219e328491b0853b8554c5a694add344d2c6cfb"
+      },
+      {
+        "version": "5.0",
+        "commit": "3219e328491b0853b8554c5a694add344d2c6cfb"
       }
     ],
     "platforms": [
@@ -3037,6 +3317,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "281a70b69783891900be31a9e70051b6fe19e146"
+      },
+      {
+        "version": "5.0",
         "commit": "281a70b69783891900be31a9e70051b6fe19e146"
       }
     ],
@@ -3062,6 +3346,10 @@
       {
         "version": "4.2",
         "commit": "db35b1c35aabd0f5db3abca0cfda7becfe9c43e2"
+      },
+      {
+        "version": "5.0",
+        "commit": "db35b1c35aabd0f5db3abca0cfda7becfe9c43e2"
       }
     ],
     "platforms": [
@@ -3086,6 +3374,10 @@
       {
         "version": "4.2",
         "commit": "cbfe7ef6301557d3f2d0807a98165232ae06e1c6"
+      },
+      {
+        "version": "5.0",
+        "commit": "cbfe7ef6301557d3f2d0807a98165232ae06e1c6"
       }
     ],
     "platforms": [
@@ -3109,6 +3401,10 @@
     "compatibility": [
       {
         "version": "4.2",
+        "commit": "156f8adeac3440e868da3757777884efbc6ec0cc"
+      },
+      {
+        "version": "5.0",
         "commit": "156f8adeac3440e868da3757777884efbc6ec0cc"
       }
     ],


### PR DESCRIPTION
Added Swift 5.0 config with Swift 4.2 SHA to test Swift compiler with `-swift-version 5` flag.

Projects added with Swift 5.0 config: 

- AMScrollingNavbar
- BlueSocket
- Deferred
- fluent
- GRDB.swift
- Guitar
- Html
- JSQCoreDataKit
- KeychainAccess
- kommander
- Kronos
- line-sdk-ios-swift
- mapper
- ModelAssistant
- NetService
- ObjectMapper
- Overture
- Perfect
- PinkyPromise
- Plank
- ProcedureKit
- R.swift
- Result
- ReSwift
- RxDataSources
- Surge
- swift-nio
- SwiftLint
- SwiftyJSON
- Then
- vapor_console
- vapor_core
- vapor_database-kit
- vapor_multipart
- vapor_routing
- vapor_service
- vapor_template-kit
- vapor_url-encoded-form
- vapor_validation

Projects xFailed:
- CoreStore
- Deferred
- exercism-swift
- PinkyPromise
- ProcedureKit
- Serpent



Tested locally with master toolchain. 

```
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AMScrollingNavbar rev-parse --show-toplevel
PASS: AMScrollingNavbar, 4.0, de70ea, AMScrollingNavbar, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AMScrollingNavbar rev-parse --show-toplevel
PASS: AMScrollingNavbar, 4.2, 8bfcc8, AMScrollingNavbar, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AMScrollingNavbar rev-parse --show-toplevel
PASS: AMScrollingNavbar, 5.0, 8bfcc8, AMScrollingNavbar, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Alamofire rev-parse --show-toplevel
PASS: Alamofire, 4.0, a5cd9e, Alamofire iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Alamofire rev-parse --show-toplevel
PASS: Alamofire, 4.0, a5cd9e, Alamofire macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Alamofire rev-parse --show-toplevel
PASS: Alamofire, 4.0, a5cd9e, Alamofire tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Alamofire rev-parse --show-toplevel
PASS: Alamofire, 4.0, a5cd9e, Alamofire watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Alamofire rev-parse --show-toplevel
PASS: Alamofire, 4.0, a5cd9e, iOS Example, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AsyncNinja rev-parse --show-toplevel
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AsyncNinja rev-parse --show-toplevel
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AsyncNinja rev-parse --show-toplevel
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/AsyncNinja rev-parse --show-toplevel
PASS: AsyncNinja, 4.0, efc83b, AsyncNinja, generic/platform=watchOS
PASS: AsyncNinja, 4.0, efc83b, Swift Package
PASS: BeaconKit, 4.0, 6e6b0f, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/BlueSocket rev-parse --show-toplevel
PASS: BlueSocket, 4.2, fb4e74, Socket, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/BlueSocket rev-parse --show-toplevel
PASS: BlueSocket, 4.2, fb4e74, Socket-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/BlueSocket rev-parse --show-toplevel
PASS: BlueSocket, 5.0, fb4e74, Socket, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/BlueSocket rev-parse --show-toplevel
PASS: BlueSocket, 5.0, fb4e74, Socket-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Chatto rev-parse --show-toplevel
PASS: Chatto, 4.0.3, 3e4b1a, Chatto, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Chatto rev-parse --show-toplevel
PASS: Chatto, 4.0.3, 3e4b1a, ChattoAdditions, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Chatto/ChattoApp rev-parse --show-toplevel
PASS: Chatto, 4.0.3, 3e4b1a, ChattoApp, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CleanroomLogger rev-parse --show-toplevel
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CleanroomLogger rev-parse --show-toplevel
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CleanroomLogger rev-parse --show-toplevel
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CleanroomLogger rev-parse --show-toplevel
PASS: CleanroomLogger, 4.0, 7a75a8, CleanroomLogger, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.0, 83e608, CoreStore iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.0, 83e608, CoreStore OSX, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.0, 83e608, CoreStore tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.0, 83e608, CoreStore watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.2, 286360, CoreStore iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.2, 286360, CoreStore OSX, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.2, 286360, CoreStore tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
PASS: CoreStore, 4.2, 286360, CoreStore watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore OSX, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/CoreStore rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/cub rev-parse --show-toplevel
PASS: cub, 4.0.3, 3574d3, Cub iOS [Double], generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/cub rev-parse --show-toplevel
PASS: cub, 4.0.3, 3574d3, Cub macOS Release [Double], generic/platform=macOS
PASS: DNS, 4.0, 04ae84, Swift Package
PASS: Deferred, 4.2, c374a6, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 4.2, c374a6, MobileDeferred, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 4.2, c374a6, TVDeferred, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 4.2, c374a6, NanoDeferred, generic/platform=watchOS
PASS: Deferred, 5.0, c374a6, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, MobileDeferred, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, TVDeferred, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Deferred rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, NanoDeferred, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Dollar rev-parse --show-toplevel
PASS: Dollar, 4.0, 433d4b, Dollar, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Dwifft rev-parse --show-toplevel
PASS: Dwifft, 4.0, 6e09d2, Dwifft, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Evergreen rev-parse --show-toplevel
PASS: Evergreen, 4.0, ce0d24, Evergreen, generic/platform=macOS
XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-swift, 4.2, 38a17d, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-swift, 5.0, 38a17d, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/exercism-xswift rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-xswift, 4.0, 7614aa, xswift, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/exercism-xswift rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-xswift, 4.1, 7614aa, xswift, generic/platform=macOS
PASS: fluent, 4.2, 270b6f, Swift Package
PASS: fluent, 5.0, 270b6f, Swift Package
PASS: GRDB.swift, 4.2, 759c10, Swift Package
PASS: GRDB.swift, 5.0, 759c10, Swift Package
PASS: Guitar, 4.2, c0e68b, Swift Package
PASS: Guitar, 5.0, c0e68b, Swift Package
PASS: Html, 4.2, e6952b, Swift Package
PASS: Html, 5.0, e6952b, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/IBAnimatable rev-parse --show-toplevel
PASS: IBAnimatable, 4.0, eb4acb, IBAnimatable, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/IBAnimatable rev-parse --show-toplevel
PASS: IBAnimatable, 4.0, eb4acb, IBAnimatableApp, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/JSQCoreDataKit rev-parse --show-toplevel
PASS: JSQCoreDataKit, 4.2, e65188, JSQCoreDataKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/JSQCoreDataKit rev-parse --show-toplevel
PASS: JSQCoreDataKit, 5.0, e65188, JSQCoreDataKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/JSQDataSourcesKit rev-parse --show-toplevel
PASS: JSQDataSourcesKit, 4.0, 25ee7e, JSQDataSourcesKit-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 4.2, 0fffcc, KeychainAccess, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 4.2, 0fffcc, KeychainAccess, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 4.2, 0fffcc, KeychainAccess, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 4.2, 0fffcc, KeychainAccess, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 5.0, 0fffcc, KeychainAccess, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 5.0, 0fffcc, KeychainAccess, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 5.0, 0fffcc, KeychainAccess, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/KeychainAccess rev-parse --show-toplevel
PASS: KeychainAccess, 5.0, 0fffcc, KeychainAccess, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kickstarter-Prelude rev-parse --show-toplevel
PASS: Kickstarter-Prelude, 4.0, 8988b0, Prelude-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kickstarter-Prelude rev-parse --show-toplevel
PASS: Kickstarter-Prelude, 4.0, 8988b0, Prelude-UIKit-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kickstarter-ReactiveExtensions rev-parse --show-toplevel
PASS: Kickstarter-ReactiveExtensions, 4.0, 6b7887, ReactiveExtensions-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kickstarter-ReactiveExtensions rev-parse --show-toplevel
PASS: Kickstarter-ReactiveExtensions, 4.0, 6b7887, ReactiveExtensions-TestHelpers-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 4.0, a5d121, Kingfisher, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 4.0, a5d121, Kingfisher-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 4.0, a5d121, Kingfisher-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 4.0, a5d121, Kingfisher-watchOS, generic/platform=watchOS
PASS: Kitura, 4.0, f1c316, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.0, d38491, Kronos, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.0, d38491, Kronos, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.0, d38491, Kronos, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.0, d38491, Kronos, generic/platform=iOS
PASS: Kronos, 4.0, d38491, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.2, d38491, Kronos, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.2, d38491, Kronos, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.2, d38491, Kronos, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 4.2, d38491, Kronos, generic/platform=iOS
PASS: Kronos, 4.2, d38491, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 5.0, d38491, Kronos, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 5.0, d38491, Kronos, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 5.0, d38491, Kronos, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Kronos rev-parse --show-toplevel
PASS: Kronos, 5.0, d38491, Kronos, generic/platform=iOS
PASS: Kronos, 5.0, d38491, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8234, Lark, 4.0, 7604f9, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/line-sdk-ios-swift rev-parse --show-toplevel
PASS: line-sdk-ios-swift, 4.2, d8bb2b, LineSDK, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/line-sdk-ios-swift rev-parse --show-toplevel
PASS: line-sdk-ios-swift, 5.0, d8bb2b, LineSDK, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ModelAssistant rev-parse --show-toplevel
PASS: ModelAssistant, 4.2, e88083, ModelAssistant iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ModelAssistant rev-parse --show-toplevel
PASS: ModelAssistant, 5.0, e88083, ModelAssistant iOS, generic/platform=iOS
XFAIL: https://bugs.swift.org/browse/SR-8234, Moya, 4.0, 4b3ff7, Swift Package
PASS: NetService, 4.2, 927eb1, Swift Package
PASS: NetService, 5.0, 927eb1, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/NonEmpty rev-parse --show-toplevel
PASS: NonEmpty, 4.1, 1fe868, NonEmpty-Package, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/NonEmpty rev-parse --show-toplevel
PASS: NonEmpty, 4.1, 1fe868, NonEmpty-Package, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/NonEmpty rev-parse --show-toplevel
PASS: NonEmpty, 4.1, 1fe868, NonEmpty-Package, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/NonEmpty rev-parse --show-toplevel
PASS: NonEmpty, 4.1, 1fe868, NonEmpty-Package, generic/platform=watchOS
PASS: NonEmpty, 4.1, 1fe868, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-Mac, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 4.2, ed1caa, ObjectMapper-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 5.0, ed1caa, ObjectMapper-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 5.0, ed1caa, ObjectMapper-Mac, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 5.0, ed1caa, ObjectMapper-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ObjectMapper rev-parse --show-toplevel
PASS: ObjectMapper, 5.0, ed1caa, ObjectMapper-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 4.2, 1632b5, Overture-Package, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 4.2, 1632b5, Overture-Package, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 4.2, 1632b5, Overture-Package, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 4.2, 1632b5, Overture-Package, generic/platform=watchOS
PASS: Overture, 4.2, 1632b5, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 5.0, 1632b5, Overture-Package, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 5.0, 1632b5, Overture-Package, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 5.0, 1632b5, Overture-Package, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Overture rev-parse --show-toplevel
PASS: Overture, 5.0, 1632b5, Overture-Package, generic/platform=watchOS
PASS: Overture, 5.0, 1632b5, Swift Package
PASS: Perfect, 4.2, cdc17d, Swift Package
PASS: Perfect, 5.0, cdc17d, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PinkyPromise rev-parse --show-toplevel
PASS: PinkyPromise, 4.2, 5c1563, PinkyPromise_iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PinkyPromise rev-parse --show-toplevel
PASS: PinkyPromise, 4.2, 5c1563, PinkyPromise_macOS, generic/platform=macOS
XFAIL: https://bugs.swift.org/browse/SR-8250, PinkyPromise, 4.2, 5c1563, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PinkyPromise rev-parse --show-toplevel
PASS: PinkyPromise, 5.0, 5c1563, PinkyPromise_iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PinkyPromise rev-parse --show-toplevel
PASS: PinkyPromise, 5.0, 5c1563, PinkyPromise_macOS, generic/platform=macOS
XFAIL: https://bugs.swift.org/browse/SR-8250, PinkyPromise, 5.0, 5c1563, Swift Package
PASS: Plank, 4.2, 71a3a5, Swift Package
PASS: Plank, 5.0, 71a3a5, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 4.2, 94193d, ProcedureKit, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 4.2, 94193d, ProcedureKitCloud, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
PASS: ProcedureKit, 5.0, 94193d, ProcedureKit, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ProcedureKit rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKitCloud, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PromiseKit rev-parse --show-toplevel
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PromiseKit rev-parse --show-toplevel
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PromiseKit rev-parse --show-toplevel
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/PromiseKit rev-parse --show-toplevel
PASS: PromiseKit, 4.0.3, c538a2, PromiseKit, generic/platform=tvOS
PASS: R.swift, 4.2, f96758, Swift Package
PASS: R.swift, 5.0, f96758, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Re-Lax rev-parse --show-toplevel
PASS: Re-Lax, 4.0, 450208, ReLax, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 4.2, beeb3c, ReSwift-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 4.2, beeb3c, ReSwift-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 4.2, beeb3c, ReSwift-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 4.2, beeb3c, ReSwift-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 5.0, beeb3c, ReSwift-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 5.0, beeb3c, ReSwift-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 5.0, beeb3c, ReSwift-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReSwift rev-parse --show-toplevel
PASS: ReSwift, 5.0, beeb3c, ReSwift-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveCocoa rev-parse --show-toplevel
PASS: ReactiveCocoa, 4.0, 72dd20, ReactiveCocoa-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveCocoa rev-parse --show-toplevel
PASS: ReactiveCocoa, 4.0, 72dd20, ReactiveCocoa-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveCocoa rev-parse --show-toplevel
PASS: ReactiveCocoa, 4.0, 72dd20, ReactiveCocoa-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveCocoa rev-parse --show-toplevel
PASS: ReactiveCocoa, 4.0, 72dd20, ReactiveCocoa-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveSwift rev-parse --show-toplevel
PASS: ReactiveSwift, 4.0, 46fb4d, ReactiveSwift-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveSwift rev-parse --show-toplevel
PASS: ReactiveSwift, 4.0, 46fb4d, ReactiveSwift-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveSwift rev-parse --show-toplevel
PASS: ReactiveSwift, 4.0, 46fb4d, ReactiveSwift-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/ReactiveSwift rev-parse --show-toplevel
PASS: ReactiveSwift, 4.0, 46fb4d, ReactiveSwift-watchOS, generic/platform=watchOS
PASS: Result, 4.2, 2fe5b3, Swift Package
PASS: Result, 5.0, 2fe5b3, Swift Package
PASS: RxDataSources, 4.2, 545873, Swift Package
PASS: RxDataSources, 5.0, 545873, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxSwift-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxCocoa-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxBlocking-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxTests-macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxTests-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/RxSwift rev-parse --show-toplevel
PASS: RxSwift, 4.0.3, 3e8487, RxTests-tvOS, generic/platform=tvOS
PASS: SRP, 4.0, b16683, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8250, Serpent, 4.2, 33ce18, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8250, Serpent, 5.0, 33ce18, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8046, Sourcery, 4.0, 6e2989, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Starscream/examples/AutobahnTest rev-parse --show-toplevel
PASS: Starscream, 4.0, 114e5d, Starscream, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Starscream/examples/SimpleTest rev-parse --show-toplevel
PASS: Starscream, 4.0, 114e5d, Starscream, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Starscream rev-parse --show-toplevel
PASS: Starscream, 4.0, 114e5d, Starscream, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 4.2, 38a328, Surge-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 4.2, 38a328, Surge-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 4.2, 38a328, Surge-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 4.2, 38a328, Surge-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 5.0, 38a328, Surge-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 5.0, 38a328, Surge-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 5.0, 38a328, Surge-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Surge rev-parse --show-toplevel
PASS: Surge, 5.0, 38a328, Surge-watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftDate rev-parse --show-toplevel
PASS: SwiftDate, 4.0, 744a8c, SwiftDate-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftDate rev-parse --show-toplevel
PASS: SwiftDate, 4.0, 744a8c, SwiftDate-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftDate rev-parse --show-toplevel
PASS: SwiftDate, 4.0, 744a8c, SwiftDate-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftDate rev-parse --show-toplevel
PASS: SwiftDate, 4.0, 744a8c, SwiftDate-watchOS, generic/platform=watchOS
PASS: SwiftGraph, 4.0, 6c8c5d, Swift Package
PASS: SwiftLint, 4.0, 60f98e, Swift Package
PASS: SwiftLint, 4.2, 60f98e, Swift Package
PASS: SwiftLint, 5.0, 60f98e, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwifterSwift rev-parse --show-toplevel
PASS: SwifterSwift, 4.0, d3c3fd, SwifterSwift-iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwifterSwift rev-parse --show-toplevel
PASS: SwifterSwift, 4.0, d3c3fd, SwifterSwift-macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwifterSwift rev-parse --show-toplevel
PASS: SwifterSwift, 4.0, d3c3fd, SwifterSwift-tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwifterSwift rev-parse --show-toplevel
PASS: SwifterSwift, 4.0, d3c3fd, SwifterSwift-watchOS, generic/platform=watchOS
PASS: swift-nio, 4.2, e56d1c, Swift Package
PASS: swift-nio, 5.0, e56d1c, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 4.2, b93c5d, SwiftyJSON macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 4.2, b93c5d, SwiftyJSON iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 4.2, b93c5d, SwiftyJSON tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 4.2, b93c5d, SwiftyJSON watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 5.0, b93c5d, SwiftyJSON macOS, platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 5.0, b93c5d, SwiftyJSON iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 5.0, b93c5d, SwiftyJSON tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyJSON rev-parse --show-toplevel
PASS: SwiftyJSON, 5.0, b93c5d, SwiftyJSON watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyStoreKit rev-parse --show-toplevel
PASS: SwiftyStoreKit, 4.0, eaa51b, SwiftyStoreKit_iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyStoreKit rev-parse --show-toplevel
PASS: SwiftyStoreKit, 4.0, eaa51b, SwiftyStoreKit_macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/SwiftyStoreKit rev-parse --show-toplevel
PASS: SwiftyStoreKit, 4.0, eaa51b, SwiftyStoreKit_tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Tagged rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Tagged rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Tagged rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/Tagged rev-parse --show-toplevel
XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=watchOS
XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Swift Package
PASS: Then, 4.2, 3edb1c, Swift Package
PASS: Then, 5.0, 3edb1c, Swift Package
XFAIL: https://bugs.swift.org/browse/SR-8250, URBNJSONDecodableSPM, 3.1, 6dc998, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 4.2, 03555e, Kommander, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 4.2, 03555e, Kommander macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 4.2, 03555e, Kommander tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 4.2, 03555e, Kommander watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 5.0, 03555e, Kommander, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 5.0, 03555e, Kommander macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 5.0, 03555e, Kommander tvOS, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/kommander rev-parse --show-toplevel
PASS: kommander, 5.0, 03555e, Kommander watchOS, generic/platform=watchOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/launchscreensnapshot rev-parse --show-toplevel
PASS: launchscreensnapshot, 4.0, f168b4, LaunchScreenSnapshot, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.0, d501cb, Mapper, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.0, d501cb, Mapper, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.0, d501cb, Mapper, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.0, d501cb, Mapper, generic/platform=watchOS
PASS: mapper, 4.0, d501cb, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.2, d501cb, Mapper, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.2, d501cb, Mapper, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.2, d501cb, Mapper, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 4.2, d501cb, Mapper, generic/platform=watchOS
PASS: mapper, 4.2, d501cb, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 5.0, d501cb, Mapper, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 5.0, d501cb, Mapper, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 5.0, d501cb, Mapper, generic/platform=tvOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/mapper rev-parse --show-toplevel
PASS: mapper, 5.0, d501cb, Mapper, generic/platform=watchOS
PASS: mapper, 5.0, d501cb, Swift Package
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/panelkit rev-parse --show-toplevel
PASS: panelkit, 4.0.3, 3ede6e, PanelKit, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/panelkit rev-parse --show-toplevel
PASS: panelkit, 4.0.3, 3ede6e, Example, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/siesta rev-parse --show-toplevel
PASS: siesta, 4.0, 926127, Siesta iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/siesta rev-parse --show-toplevel
PASS: siesta, 4.0, 926127, Siesta macOS, generic/platform=macOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/siesta rev-parse --show-toplevel
PASS: siesta, 4.0, 926127, SiestaUI iOS, generic/platform=iOS
$ git -C /Users/mishal_shah/src/github/swift-source-compat-suite/project_cache/siesta rev-parse --show-toplevel
PASS: siesta, 4.0, 926127, SiestaUI macOS, generic/platform=macOS
PASS: vapor_console, 4.2, 5b9796, Swift Package
PASS: vapor_console, 5.0, 5b9796, Swift Package
PASS: vapor_core, 4.2, 08a576, Swift Package
PASS: vapor_core, 5.0, 08a576, Swift Package
PASS: vapor_database-kit, 4.2, 3a17db, Swift Package
PASS: vapor_database-kit, 5.0, 3a17db, Swift Package
PASS: vapor_multipart, 4.2, e57007, Swift Package
PASS: vapor_multipart, 5.0, e57007, Swift Package
PASS: vapor_routing, 4.2, 3219e3, Swift Package
PASS: vapor_routing, 5.0, 3219e3, Swift Package
PASS: vapor_service, 4.2, 281a70, Swift Package
PASS: vapor_service, 5.0, 281a70, Swift Package
PASS: vapor_template-kit, 4.2, db35b1, Swift Package
PASS: vapor_template-kit, 5.0, db35b1, Swift Package
PASS: vapor_url-encoded-form, 4.2, cbfe7e, Swift Package
PASS: vapor_url-encoded-form, 5.0, cbfe7e, Swift Package
PASS: vapor_validation, 4.2, 156f8a, Swift Package
PASS: vapor_validation, 5.0, 156f8a, Swift Package
========================================
XFailures:
  XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore watchOS, generic/platform=watchOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore tvOS, generic/platform=tvOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore OSX, generic/platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, CoreStore, 5.0, 286360, CoreStore iOS, generic/platform=iOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, NanoDeferred, generic/platform=watchOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, TVDeferred, generic/platform=tvOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, Deferred, 5.0, c374a6, MobileDeferred, generic/platform=iOS
  XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-swift, 5.0, 38a17d, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-swift, 4.2, 38a17d, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-xswift, 4.1, 7614aa, xswift, generic/platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-8307, exercism-xswift, 4.0, 7614aa, xswift, generic/platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-8234, Lark, 4.0, 7604f9, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8234, Moya, 4.0, 4b3ff7, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8250, PinkyPromise, 5.0, 5c1563, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8250, PinkyPromise, 4.2, 5c1563, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKitCloud, platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, generic/platform=tvOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, generic/platform=iOS
  XFAIL: https://bugs.swift.org/browse/SR-9899, ProcedureKit, 5.0, 94193d, ProcedureKit, platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-8250, Serpent, 5.0, 33ce18, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8250, Serpent, 4.2, 33ce18, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-8046, Sourcery, 4.0, 6e2989, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Swift Package
  XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=watchOS
  XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=tvOS
  XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=iOS
  XFAIL: https://bugs.swift.org/browse/SR-9252, Tagged, 4.1, 6e0798, Tagged-Package, generic/platform=macOS
  XFAIL: https://bugs.swift.org/browse/SR-8250, URBNJSONDecodableSPM, 3.1, 6dc998, Swift Package
========================================
Action Summary:
     Passed: 261
     Failed: 0
    XFailed: 28
    UPassed: 0
      Total: 289
========================================
Repository Summary:
      Total: 79
========================================
Result: XFAIL
========================================

```