### PR TITLE
[Add] Bond and ReactiveKit

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -232,6 +232,51 @@
   },
   {
     "repository": "Git",
+    "url": "git@github.com:DeclarativeHub/Bond.git",
+    "path": "Bond",
+    "branch": "master",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "256bb4bb2492670dd0f9957a7c0b178137b60a3a"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "maintainer": "srdan.rasic@gmail.com",
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Bond.xcworkspace",
+        "scheme": "Bond-macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Bond.xcworkspace",
+        "scheme": "Bond-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "Bond.xcworkspace",
+        "scheme": "Bond-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "TestXcodeWorkspaceScheme",
+        "workspace": "Bond.xcworkspace",
+        "scheme": "Bond-iOS",
+        "destination": "platform=iOS Simulator,name=iPhone XS"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/badoo/Chatto.git",
     "path": "Chatto",
     "branch": "master",

--- a/projects.json
+++ b/projects.json
@@ -232,7 +232,7 @@
   },
   {
     "repository": "Git",
-    "url": "git@github.com:DeclarativeHub/Bond.git",
+    "url": "https://github.com/DeclarativeHub/Bond.git",
     "path": "Bond",
     "branch": "master",
     "compatibility": [
@@ -2078,6 +2078,66 @@
         "scheme": "ReactiveCocoa-watchOS",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/DeclarativeHub/ReactiveKit.git",
+    "path": "ReactiveKit",
+    "branch": "master",
+    "compatibility": [
+      {
+        "version": "4.2",
+        "commit": "fcf4a94d8e0cdd4e312286668340609bb54ff417"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "maintainer": "srdan.rasic@gmail.com",
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveKit.xcworkspace",
+        "scheme": "ReactiveKit-macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveKit.xcworkspace",
+        "scheme": "ReactiveKit-iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveKit.xcworkspace",
+        "scheme": "ReactiveKit-tvOS",
+        "destination": "generic/platform=tvOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "ReactiveKit.xcworkspace",
+        "scheme": "ReactiveKit-watchOS",
+        "destination": "generic/platform=watchOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "TestXcodeWorkspaceScheme",
+        "workspace": "ReactiveKit.xcworkspace",
+        "scheme": "ReactiveKit-iOS",
+        "destination": "platform=iOS Simulator,name=iPhone XS"
+      },
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

Adds [Bond](https://github.com/DeclarativeHub/Bond) and its sister project [ReactiveKit](https://github.com/DeclarativeHub/ReactiveKit).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.