### PR TITLE
Update stress tester xfails to separate 5.1 branch and master

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -3,6 +3,7 @@
     "path" : "*\/Alamofire\/Source\/Result.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -15,6 +16,7 @@
     "path" : "*\/AsyncNinja\/Sources\/BaseProducer.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -28,6 +30,7 @@
     "modification" : "concurrent-2781",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9378",
@@ -42,6 +45,7 @@
     "modification" : "insideOut-2255",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -57,6 +61,7 @@
     "modification" : "concurrent-1282",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -71,6 +76,7 @@
     "path" : "*\/Chatto\/Chatto\/Source\/ChatController\/BaseChatViewController+Changes.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -84,6 +90,7 @@
     "modification" : "concurrent-1515",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -97,6 +104,7 @@
     "modification" : "concurrent-2138",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -112,6 +120,7 @@
     "modification" : "concurrent-4106",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -124,6 +133,7 @@
     "path" : "*\/CoreStore\/Sources\/AsynchronousDataTransaction.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -137,6 +147,7 @@
     "modification" : "concurrent-4683",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -150,6 +161,7 @@
     "path" : "*\/Dollar\/Sources\/Dollar.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -162,6 +174,7 @@
     "path" : "*\/DNS\/Sources\/DNS\/Bytes.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -175,6 +188,7 @@
     "modification" : "concurrent-460",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -188,6 +202,7 @@
     "modification" : "concurrent-9359",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -201,6 +216,7 @@
     "modification" : "insideOut-2356",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -213,6 +229,7 @@
     "path" : "*\/Deferred\/Sources\/Task\/ResultRecovery.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -226,6 +243,7 @@
     "modification" : "concurrent-893",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -239,6 +257,7 @@
     "modification" : "insideOut-32",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -253,6 +272,7 @@
     "path" : "*\/Evergreen\/Commands\/DeleteFromSidebarCommand.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -266,6 +286,7 @@
     "modification" : "concurrent-1304",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -279,6 +300,7 @@
     "path" : "*\/fluent\/Sources\/Fluent\/Cache\/CacheEntry.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9003",
@@ -291,6 +313,7 @@
     "path" : "*\/fluent\/Sources\/FluentBenchmark\/Benchmarks\/Bar.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9003",
@@ -303,6 +326,7 @@
     "path" : "*\/fluent\/Sources\/FluentSQL\/SQL+Contains.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -315,6 +339,7 @@
     "path" : "*\/IBAnimatable\/Sources\/Animators\/InteractiveAnimator\/ScreenEdgePanInteractiveAnimator.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -328,6 +353,7 @@
     "modification" : "insideOut-3275",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -342,6 +368,7 @@
     "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -354,6 +381,7 @@
     "path" : "*\/Kickstarter-Prelude\/Prelude\/Either.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -366,6 +394,7 @@
     "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -378,6 +407,7 @@
     "path" : "*\/Kickstarter-ReactiveExtensions\/Frameworks\/ReactiveSwift\/Sources\/Action.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -391,6 +421,7 @@
     "modification" : "concurrent-495",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -403,6 +434,7 @@
     "path" : "*\/Kingfisher\/Sources\/Filter.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -415,6 +447,7 @@
     "path" : "*\/Kitura\/Sources\/Kitura\/CodableRouter.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-8566",
@@ -429,6 +462,7 @@
     "modification" : "insideOut-*",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371 TIMEOUT",
@@ -441,6 +475,7 @@
     "modification" : "insideOut-60",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -456,6 +491,7 @@
     "modification" : "insideOut-279",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -471,6 +507,7 @@
     "modification" : "insideOut-174",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -486,6 +523,7 @@
     "modification" : "insideOut-2867",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -501,6 +539,7 @@
     "modification" : "concurrent-1152",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -514,7 +553,8 @@
   {
     "path" : "*\/ProcedureKit\/Sources\/ProcedureKit\/AnyObserver.swift",
     "applicableConfigs" : [
-      "master"
+      "master",
+      "swift-5.1-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
     "issueDetail" : {
@@ -526,6 +566,7 @@
     "path" : "*\/ProcedureKit\/Sources\/ProcedureKitCloud\/CloudKit.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -539,6 +580,7 @@
     "modification" : "concurrent-496",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -551,6 +593,7 @@
     "path" : "*\/R.swift\/Sources\/RswiftCore\/Generators\/AggregatedStructGenerator.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9015",
@@ -563,6 +606,7 @@
     "path" : "*\/R.swift\/Sources\/rswift\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -575,6 +619,7 @@
     "path" : "*\/ReSwift\/ReSwift\/CoreTypes\/Store.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -587,6 +632,7 @@
     "path" : "*\/ReactiveCocoa\/ReactiveCocoa\/CocoaAction.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -599,6 +645,7 @@
     "path" : "*\/ReactiveSwift\/Sources\/Action.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -610,7 +657,8 @@
   {
     "path" : "*\/Result\/Result\/Result.swift",
     "applicableConfigs" : [
-      "master"
+      "master",
+      "swift-5.1-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
     "issueDetail" : {
@@ -635,6 +683,7 @@
     "path" : "*\/Result\/Result\/ResultProtocol.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -647,6 +696,7 @@
     "path" : "*\/RxSwift\/RxSwift\/Deprecated.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -659,6 +709,7 @@
     "path" : "*\/RxSwift\/RxCocoa\/Common\/Binder.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -671,6 +722,7 @@
     "path" : "*\/RxSwift\/RxCocoa\/Common\/Observable+Bind.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -683,6 +735,7 @@
     "path" : "*\/RxSwift\/RxTest\/Schedulers\/TestScheduler.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -695,6 +748,7 @@
     "path" : "*\/Surge\/Sources\/Surge\/Matrix.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -707,6 +761,7 @@
     "path" : "*\/Surge\/Sources\/Surge\/Matrix.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -720,6 +775,7 @@
     "modification" : "concurrent-2991",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -734,6 +790,7 @@
     "modification" : "insideOut-776",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -748,6 +805,7 @@
     "path" : "*\/SwiftGraph\/Sources\/SwiftGraph\/Cycle.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -761,6 +819,7 @@
     "modification" : "concurrent-2800",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -773,6 +832,7 @@
     "path" : "*\/SwifterSwift\/Sources\/Extensions\/AppKit\/NSImageExtensions.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -786,6 +846,7 @@
     "modification" : "insideOut-1111",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -799,6 +860,7 @@
     "modification" : "insideOut-100",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -814,6 +876,7 @@
     "modification" : "concurrent-2857",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -826,6 +889,7 @@
     "path" : "*\/swift-nio\/Sources\/NIO\/BaseSocket.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -838,6 +902,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOEchoServer\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -850,6 +915,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOEchoClient\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -862,6 +928,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOChatServer\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -874,6 +941,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOChatClient\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -887,6 +955,7 @@
     "modification" : "concurrent-3530",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -900,6 +969,7 @@
     "modification" : "concurrent-3499",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -913,6 +983,7 @@
     "modification" : "concurrent-3864",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -925,6 +996,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOWebSocket\/Base64.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -937,6 +1009,7 @@
     "path" : "*\/swift-nio\/Sources\/NIOWebSocketServer\/main.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -950,6 +1023,7 @@
     "modification" : "insideOut-3580",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -963,6 +1037,7 @@
     "modification" : "concurrent-2809",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -975,6 +1050,7 @@
     "path" : "*\/mapper\/Sources\/Mapper.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-8566",
@@ -988,6 +1064,7 @@
     "path" : "*\/panelkit\/PanelKit\/PanelManager\/PanelManager+AutoLayout.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1000,6 +1077,7 @@
     "path" : "*\/panelkit\/PanelKit\/PanelManager\/PanelManager+Pinning.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1013,6 +1091,7 @@
     "modification" : "concurrent-1328",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1026,6 +1105,7 @@
     "path" : "*\/vapor_core\/Sources\/Bits\/ByteBuffer+binaryFloatingPointOperations.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1039,6 +1119,7 @@
     "modification" : "insideOut-455",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1052,6 +1133,7 @@
     "modification" : "concurrent-6045",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1065,6 +1147,7 @@
     "modification" : "insideOut-398",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1079,6 +1162,7 @@
     "path" : "*\/vapor_multipart\/Sources\/Multipart\/FormDataDecoder.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1093,6 +1177,7 @@
     "modification" : "concurrent-3003",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1106,6 +1191,7 @@
     "modification" : "insideOut-211",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1120,6 +1206,7 @@
     "path" : "*\/vapor_url-encoded-form\/Sources\/URLEncodedForm\/Codable\/URLEncodedFormDecoder.swift",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1134,6 +1221,7 @@
     "modification" : "concurrent-737",
     "applicableConfigs" : [
       "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -13,6 +13,30 @@
     }
   },
   {
+    "path" : "*\/Alamofire\/Source\/MultipartFormData.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 18150
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+  },
+  {
+    "path" : "*\/AMScrollingNavbar\/Source\/ScrollingNavigationController.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 15034
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+  },
+  {
     "path" : "*\/AsyncNinja\/Sources\/BaseProducer.swift",
     "applicableConfigs" : [
       "master",
@@ -74,6 +98,18 @@
   },
   {
     "path" : "*\/Chatto\/Chatto\/Source\/ChatController\/BaseChatViewController+Changes.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 9565
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Chatto\/Chatto\/Source\/ChatController\/BaseChatViewController+Changes.swift",
     "applicableConfigs" : [
       "master",
       "swift-5.1-branch",
@@ -98,6 +134,18 @@
       "kind" : "cursorInfo",
       "offset" : 1345
     }
+  },
+  {
+    "path" : "*\/Chatto\/ChattoAdditions\/Source\/Chat Items\/BaseMessage\/BaseMessagePresenter.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 8273
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
   },
   {
     "path" : "*\/Chatto\/ChattoAdditions\/Source\/Chat Items\/BaseMessage\/BaseMessageViewModel.swift",
@@ -130,6 +178,17 @@
     }
   },
   {
+    "path" : "*\/CleanroomLogger\/Sources\/SeverityLogFormatter.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 6102
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/CoreStore\/Sources\/AsynchronousDataTransaction.swift",
     "applicableConfigs" : [
       "master",
@@ -158,10 +217,32 @@
     }
   },
   {
-    "path" : "*\/Dollar\/Sources\/Dollar.swift",
+    "path" : "*\/cub\/Sources\/Cub\/AST\/Nodes\/ArrayNode.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1016
+    },
     "applicableConfigs" : [
       "master",
-      "swift-5.1-branch",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+  },
+  {
+    "path" : "*\/Dollar\/Sources\/Dollar.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1766
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-10154"
+  },
+  {
+    "path" : "*\/Dollar\/Sources\/Dollar.swift",
+    "applicableConfigs" : [
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -173,8 +254,6 @@
   {
     "path" : "*\/DNS\/Sources\/DNS\/Bytes.swift",
     "applicableConfigs" : [
-      "master",
-      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -182,6 +261,18 @@
       "kind" : "codeComplete",
       "offset" : 2844
     }
+  },
+  {
+    "path" : "*\/DNS\/Sources\/DNS\/Bytes.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 5852
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-10154"
   },
   {
     "path" : "*\/DNS\/Sources\/DNS\/Integer+Data.swift",
@@ -212,6 +303,17 @@
     }
   },
   {
+    "path" : "*\/Deferred\/Sources\/Deferred\/Deferred.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1918
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+  },
+  {
     "path" : "*\/Deferred\/Sources\/Deferred\/DeferredQueue.swift",
     "modification" : "insideOut-2356",
     "applicableConfigs" : [
@@ -224,6 +326,18 @@
       "kind" : "cursorInfo",
       "offset" : 312
     }
+  },
+  {
+    "path" : "*\/Deferred\/Sources\/Task\/ResultFuture.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2999
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
   },
   {
     "path" : "*\/Deferred\/Sources\/Task\/ResultRecovery.swift",
@@ -251,6 +365,30 @@
       "kind" : "cursorInfo",
       "offset" : 887
     }
+  },
+  {
+    "path" : "*\/Evergreen\/Frameworks\/Account\/CombinedRefreshProgress.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 943
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Evergreen\/Frameworks\/Data\/Attachment.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 943
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Evergreen\/Frameworks\/Database\/Database.swift",
@@ -297,6 +435,66 @@
     }
   },
   {
+    "path" : "*\/Evergreen\/submodules\/RSWeb\/RSWeb\/Dictionary+RSWeb.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 692
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Evergreen\/submodules\/RSTree\/RSTree\/Node.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1339
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Evergreen\/submodules\/RSParser\/Sources\/Feeds\/JSON\/RSSInJSONParser.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 3510
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "\/Evergreen\/submodules\/RSCore\/RSCore\/AppKit\/LogWindowController.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 726
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/fluent\/Sources\/Fluent\/Migration\/MigrationConfig.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2929
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/fluent\/Sources\/Fluent\/Cache\/CacheEntry.swift",
     "applicableConfigs" : [
       "master",
@@ -323,6 +521,20 @@
     }
   },
   {
+    "path" : "*\/fluent\/Sources\/FluentBenchmark\/Benchmarks\/BenchmarkAggregate.swift",
+    "modification" : "concurrent-477",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 469
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/fluent\/Sources\/FluentSQL\/SQL+Contains.swift",
     "applicableConfigs" : [
       "master",
@@ -334,6 +546,42 @@
       "kind" : "codeComplete",
       "offset" : 215
     }
+  },
+  {
+    "path" : "*\/fluent\/Sources\/FluentSQL\/SQL+SchemaSupporting.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4214
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/GRDB.swift\/GRDB\/Core\/Cursor.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 15938
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/IBAnimatable\/Sources\/ActivityIndicators\/Animations\/ActivityIndicatorAnimationCirclePendulum.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1289
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/IBAnimatable\/Sources\/Animators\/InteractiveAnimator\/ScreenEdgePanInteractiveAnimator.swift",
@@ -365,10 +613,20 @@
     }
   },
   {
-    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "path" : "*\/JSQDataSourcesKit\/Source\/ReusableViewConfig.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4456
+    },
     "applicableConfigs" : [
       "master",
-      "swift-5.1-branch",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "applicableConfigs" : [
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -376,6 +634,20 @@
       "kind" : "codeComplete",
       "offset" : 1436
     }
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "modification" : "concurrent-1917",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1910
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Kickstarter-Prelude\/Prelude\/Either.swift",
@@ -391,17 +663,31 @@
     }
   },
   {
-    "path" : "*\/Kickstarter-Prelude\/Frameworks\/Runes\/Sources\/Runes\/Optional\/Optional+Applicative.swift",
+    "path" : "*\/Kickstarter-Prelude\/Prelude\/Either.swift",
+    "modification" : "concurrent-1967",
+    "issueDetail" : {
+      "kind" : "cursorInfo",
+      "offset" : 1212
+    },
     "applicableConfigs" : [
       "master",
-      "swift-5.1-branch",
-      "swift-5.0-branch"
+      "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Kickstarter-Prelude\/Prelude-UIKit\/lenses\/UIButtonLenses.swift",
+    "modification" : "concurrent-522",
     "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 1436
-    }
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 517
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Kickstarter-ReactiveExtensions\/Frameworks\/ReactiveSwift\/Sources\/Action.swift",
@@ -458,11 +744,46 @@
     }
   },
   {
+    "path" : "*\/Kitura\/Sources\/Kitura\/CodableRouter+TypeSafeMiddleware.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2560
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Kronos\/Sources\/Clock.swift",
+    "modification" : "concurrent-866",
+    "issueDetail" : {
+      "kind" : "cursorInfo",
+      "offset" : 855
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/NetService\/Sources\/NetService\/Utils.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 8406
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/NetService\/Sources\/NetService\/Utils.swift",
     "modification" : "insideOut-*",
     "applicableConfigs" : [
-      "master",
-      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371 TIMEOUT",
@@ -487,6 +808,17 @@
     }
   },
   {
+    "path" : "*\/Perfect\/Sources\/PerfectLib\/Bytes.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 3698
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/Perfect\/Sources\/PerfectLib\/SysProcess.swift",
     "modification" : "insideOut-279",
     "applicableConfigs" : [
@@ -503,6 +835,32 @@
     }
   },
   {
+    "path" : "*\/PinkyPromise\/Sources\/Promise.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 13390
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/Plank\/Sources\/Core\/FileGenerator.swift",
+    "modification" : "concurrent-3007",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1997
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/Plank\/Sources\/Core\/JSIR.swift",
     "modification" : "insideOut-174",
     "applicableConfigs" : [
@@ -517,6 +875,18 @@
       "offset" : 94,
       "text" : " "
     }
+  },
+  {
+    "path" : "*\/Plank\/Sources\/plank\/Cli.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 5100
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Plank\/Sources\/plank\/Cli.swift",
@@ -603,6 +973,21 @@
     }
   },
   {
+    "path" : "*\/R.swift\/Sources\/RswiftCore\/Generators\/AssetSubfolders.swift",
+    "modification" : "insideOut-366",
+    "issueDetail" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 36,
+      "text" : ")"
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/R.swift\/Sources\/rswift\/main.swift",
     "applicableConfigs" : [
       "master",
@@ -616,6 +1001,30 @@
     }
   },
   {
+    "path" : "*\/Re-Lax\/ReLax\/ReLax\/DataHelpers.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1722
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/ReSwift\/ReSwift\/CoreTypes\/Store.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 883
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/ReSwift\/ReSwift\/CoreTypes\/Store.swift",
     "applicableConfigs" : [
       "master",
@@ -627,6 +1036,20 @@
       "kind" : "codeComplete",
       "offset" : 3943
     }
+  },
+  {
+    "path" : "*\/ReactiveCocoa\/ReactiveCocoa\/AppKit\/ActionProxy.swift",
+    "modification" : "concurrent-1045",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 1041
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/ReactiveCocoa\/ReactiveCocoa\/CocoaAction.swift",
@@ -694,6 +1117,18 @@
   },
   {
     "path" : "*\/RxSwift\/RxSwift\/Deprecated.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 3319
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/RxSwift\/RxSwift\/Deprecated.swift",
     "applicableConfigs" : [
       "master",
       "swift-5.1-branch",
@@ -704,6 +1139,20 @@
       "kind" : "codeComplete",
       "offset" : 10051
     }
+  },
+  {
+    "path" : "*\/RxSwift\/RxBlocking\/BlockingObservable+Operators.swift",
+    "modification" : "concurrent-3679",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 3679
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/RxSwift\/RxCocoa\/Common\/Binder.swift",
@@ -732,6 +1181,18 @@
     }
   },
   {
+    "path" : "*\/RxSwift\/RxTest\/Event+Equatable.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 660
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/RxSwift\/RxTest\/Schedulers\/TestScheduler.swift",
     "applicableConfigs" : [
       "master",
@@ -745,6 +1206,18 @@
     }
   },
   {
+    "path" : "*\/Starscream\/Sources\/SSLSecurity.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4702
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "<issue url>"
+  },
+  {
     "path" : "*\/Surge\/Sources\/Surge\/Matrix.swift",
     "applicableConfigs" : [
       "master",
@@ -756,6 +1229,18 @@
       "kind" : "codeComplete",
       "offset" : 2970
     }
+  },
+  {
+    "path" : "*\/Surge\/Sources\/Surge\/Matrix.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4331
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Surge\/Sources\/Surge\/Matrix.swift",
@@ -784,6 +1269,18 @@
       "refactoring" : "Local Rename",
       "offset" : 1582
     }
+  },
+  {
+    "path" : "*\/SwiftDate\/Sources\/SwiftDate\/DateInRegion\/DateInRegion+Components.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2319
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/SwiftDate\/Sources\/SwiftDate\/DateInRegion\/DateInRegion.swift",
@@ -842,6 +1339,32 @@
     }
   },
   {
+    "path" : "*\/SwifterSwift\/Sources\/Extensions\/Foundation\/NSAttributedStringExtensions.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4982
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/SwiftLint\/Source\/SwiftLintFramework\/Extensions\/Array+SwiftLint.swift",
+    "modification" : "concurrent-565",
+    "issueDetail" : {
+      "kind" : "semanticRefactoring",
+      "refactoring" : "Local Rename",
+      "offset" : 558
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/SwiftLint\/Source\/SwiftLintFramework\/Extensions\/Configuration+LintableFiles.swift",
     "modification" : "insideOut-1111",
     "applicableConfigs" : [
@@ -854,6 +1377,18 @@
       "kind" : "cursorInfo",
       "offset" : 225
     }
+  },
+  {
+    "path" : "*\/SwiftLint\/Source\/swiftlint\/Extensions\/Configuration+CommandLine.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 3102
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/SwiftLint\/Source\/swiftlint\/Extensions\/Configuration+CommandLine.swift",
@@ -870,6 +1405,18 @@
       "offset" : 50,
       "text" : "' ("
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOPriorityQueue\/Heap.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 7502
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOPriorityQueue\/PriorityQueue.swift",
@@ -899,6 +1446,30 @@
     }
   },
   {
+    "path" : "*\/swift-nio\/Sources\/NIO\/BaseSocketChannel.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 12938
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOEchoServer\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1812
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/swift-nio\/Sources\/NIOEchoServer\/main.swift",
     "applicableConfigs" : [
       "master",
@@ -910,6 +1481,18 @@
       "kind" : "codeComplete",
       "offset" : 3688
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOEchoClient\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 869
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOEchoClient\/main.swift",
@@ -926,6 +1509,18 @@
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOChatServer\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 5347
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOChatServer\/main.swift",
     "applicableConfigs" : [
       "master",
       "swift-5.1-branch",
@@ -936,6 +1531,18 @@
       "kind" : "codeComplete",
       "offset" : 7267
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOChatClient\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1978
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOChatClient\/main.swift",
@@ -952,6 +1559,17 @@
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOHTTP1\/HTTPDecoder.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 5085
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOHTTP1\/HTTPDecoder.swift",
     "modification" : "concurrent-3530",
     "applicableConfigs" : [
       "master",
@@ -963,6 +1581,17 @@
       "kind" : "cursorInfo",
       "offset" : 2284
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOHTTP1Server\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4208
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOFoundationCompat\/ByteBuffer-foundation.swift",
@@ -977,6 +1606,17 @@
       "kind" : "cursorInfo",
       "offset" : 3488
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOTLS\/ApplicationProtocolNegotiationHandler.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1668
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOTLS\/SNIHandler.swift",
@@ -994,6 +1634,18 @@
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOWebSocket\/Base64.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2641
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOWebSocket\/Base64.swift",
     "applicableConfigs" : [
       "master",
       "swift-5.1-branch",
@@ -1007,6 +1659,18 @@
   },
   {
     "path" : "*\/swift-nio\/Sources\/NIOWebSocketServer\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2788
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOWebSocketServer\/main.swift",
     "applicableConfigs" : [
       "master",
       "swift-5.1-branch",
@@ -1017,6 +1681,18 @@
       "kind" : "codeComplete",
       "offset" : 9947
     }
+  },
+  {
+    "path" : "*\/swift-nio\/Sources\/NIOPerformanceTester\/main.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 4243
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/SwiftyStoreKit\/SwiftyStoreKit\/InAppReceiptVerificator.swift",
@@ -1061,6 +1737,18 @@
     }
   },
   {
+    "path" : "*\/panelkit\/PanelKit\/Controller\/PanelViewController+Appearance.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 312
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-8566"
+  },
+  {
     "path" : "*\/panelkit\/PanelKit\/PanelManager\/PanelManager+AutoLayout.swift",
     "applicableConfigs" : [
       "master",
@@ -1088,10 +1776,20 @@
   },
   {
     "path" : "*\/siesta\/Source\/Siesta\/Pipeline\/PipelineProcessing.swift",
-    "modification" : "concurrent-1328",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1560
+    },
     "applicableConfigs" : [
       "master",
-      "swift-5.1-branch",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/siesta\/Source\/Siesta\/Pipeline\/PipelineProcessing.swift",
+    "modification" : "concurrent-1328",
+    "applicableConfigs" : [
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
@@ -1100,6 +1798,18 @@
       "refactoring" : "Local Rename",
       "offset" : 845
     }
+  },
+  {
+    "path" : "*\/vapor_console\/Sources\/Console\/Clear\/Console+Ephemeral.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1818
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/vapor_core\/Sources\/Bits\/ByteBuffer+binaryFloatingPointOperations.swift",
@@ -1129,6 +1839,18 @@
     }
   },
   {
+    "path" : "*\/vapor_core\/Sources\/Async\/Future+Flatten.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 2177
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/vapor_core\/Sources\/Core\/CodableReflection\/ReflectionDecodable.swift",
     "modification" : "concurrent-6045",
     "applicableConfigs" : [
@@ -1141,6 +1863,30 @@
       "kind" : "cursorInfo",
       "offset" : 4354
     }
+  },
+  {
+    "path" : "*\/vapor_core\/Sources\/Debugging\/Debuggable.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 6356
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
+    "path" : "*\/vapor_database-kit\/Sources\/DatabaseKit\/ConnectionPool\/DatabaseConnectionPool.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 3374
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/vapor_database-kit\/Sources\/DatabaseKit\/Database\/DatabaseConfig.swift",
@@ -1187,6 +1933,18 @@
     }
   },
   {
+    "path" : "*\/vapor_routing\/Sources\/Routing\/Parameter\/Parameters.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1690
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/vapor_service\/Sources\/Service\/Config\/Config.swift",
     "modification" : "insideOut-211",
     "applicableConfigs" : [
@@ -1203,6 +1961,18 @@
     }
   },
   {
+    "path" : "*\/vapor_template-kit\/Sources\/TemplateKit\/Data\/TemplateData.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 790
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
+  },
+  {
     "path" : "*\/vapor_url-encoded-form\/Sources\/URLEncodedForm\/Codable\/URLEncodedFormDecoder.swift",
     "applicableConfigs" : [
       "master",
@@ -1215,6 +1985,18 @@
       "refactoring" : "Local Rename",
       "offset" : 2846
     }
+  },
+  {
+    "path" : "*\/vapor_validation\/Sources\/Validation\/Validations.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 5110
+    },
+    "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/vapor_validation\/Sources\/Validation\/Validations.swift",


### PR DESCRIPTION
Also update them to account for the latest weekly master CI results.