### PR TITLE
Update 5.0 hash for CoreStore

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -358,7 +358,7 @@
       },
       {
         "version": "5.0",
-        "commit": "2863605d845cd9bb255ddd91f47f92717dec637f"
+        "commit": "b2dba0d6fd0811ce688217b842c4177bd14a84b7"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -370,18 +370,7 @@
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -389,54 +378,21 @@
         "scheme": "CoreStore OSX",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "CoreStore.xcworkspace",
         "scheme": "CoreStore watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "TestXcodeWorkspaceScheme",


### PR DESCRIPTION
### Pull Request Description

Updates the 5.0 hash for CoreStore.

rdar://49270199

- [X] pass `./project_precommit_check` script run
