### PR TITLE
Don’t SKStressTest certain projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -471,8 +471,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"
@@ -816,7 +815,6 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -2070,8 +2068,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
The “DNS”, “Guitar”, and “Result” projects are failing to build in SourceKit stress tests, apparently because of a bad interaction between SKStressTester’s swiftc wrapper and SwiftPM. Temporarily remove these projects from stress tester tests.

rdar://problem/50584688