### PR TITLE
Remove apparently fixed Dollar SourceKit XFAIL harder

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -230,17 +230,6 @@
   },
   {
     "path" : "*\/Dollar\/Sources\/Dollar.swift",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 14318
-    },
-    "applicableConfigs" : [
-      "swift-5.1-branch"
-    ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
-  },
-  {
-    "path" : "*\/Dollar\/Sources\/Dollar.swift",
     "applicableConfigs" : [
       "swift-5.0-branch"
     ],


### PR DESCRIPTION
Now that the CI job configuration has been fixed, this apparently needs to be removed entirely. rdar://50695868