### PR TITLE
[run_sk_stress_test] List all failures at the end of the run

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -471,7 +471,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestSwiftPackage"
@@ -815,6 +816,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "tags": "sourcekit sourcekit-smoke",
         "xfail": {
           "compatibility": {
             "4.0": {
@@ -2068,7 +2070,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "sourcekit sourcekit-smoke"
       },
       {
         "action": "TestSwiftPackage"

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -230,7 +230,8 @@ class StressTesterRunner(object):
             'SK_STRESS_AST_BUILD_LIMIT': '1000',
             'SK_STRESS_OUTPUT': results,
             'SK_XFAILS_PATH': self.xfails_path,
-            'SK_STRESS_ACTIVE_CONFIG': self.swift_branch}
+            'SK_STRESS_ACTIVE_CONFIG': self.swift_branch,
+            'SK_STRESS_SUPPRESS_OUTPUT': 'true'}
         run_env.update(os.environ)
         run_cmd = ['./runner.py',
           '--projects', filtered_projects,
@@ -270,6 +271,19 @@ class StressTesterRunner(object):
 
         success = num_failures == 0 and len(unmatched) == 0
 
+        if num_xfails > 0:
+            print('Expected stress tester issues:')
+            for url, issues in results['expectedIssueMessages'].iteritems():
+                for (index, issue) in enumerate(issues):
+                    self._print_issue(index, issue, url)
+            print('\n========================================')
+        if num_failures > 0:
+            print('Unexpected stress tester issues:')
+            for (index, issue) in enumerate(results['issueMessages']):
+                self._print_issue(index, issue)
+            print('\n========================================')
+
+
         print('SourceKit Stress Tester summary:')
         
         print('  {} underlying source compatibility build'.format('failed' if self.compat_runner_failed else 'passed'))
@@ -278,7 +292,7 @@ class StressTesterRunner(object):
         
         print('  {} unexpected stress tester failures'.format(num_failures))
         if num_failures > 0:
-            print('      > search "Detected unexpected failure:" for individual failures')
+            print('      > see "Unexpected stress tester issues" above for individual failures')
 
         print('  {} expected stress tester failures tracked by {} issues'.format(num_xfails, num_xfail_issues))
 
@@ -293,6 +307,13 @@ class StressTesterRunner(object):
         print('========================================')
 
         return success
+
+    @staticmethod
+    def _print_issue(index, issue, url = None):
+        if url != None:
+            print(u'\n{}. [{}] {}'.format(index + 1, url, issue))
+        else:
+            print(u'\n{}. {}'.format(index + 1, issue))
 
 
     def _filter_projects(self, output):


### PR DESCRIPTION
Sets an environment variable to suppress progress and detected failure output from sk-swiftc-wrapper and instead dump the failures at the end of the run based on what's in the results JSON file. This is to work around the CI job failing with SwiftPM projects due to the extra inline output sk-swiftc-wrapper produces on top of the wrapped compiler output not being parseable when SwiftPM builds pass
`-parseable-output`. The extra output is all on stderr as far as I can tell, which used to be enough for SwiftPM to ignore it, but something changed and I'm not sure what. This works around the problem in the meantime.

This PR also adds back the SwiftPM projects that we stopped stress testing because of this issue. The stress tester side changes that suppress output based on the environment variable are in https://github.com/apple/swift-stress-tester/pull/49 (5.0 branch), https://github.com/apple/swift-stress-tester/pull/48 (5.1 branch) and https://github.com/apple/swift-stress-tester/pull/47 (master)

Resolves rdar://problem/50584688