### PR TITLE
[run_sk_stress_test] Replace non-ascii characters when outputting to an ascii tty

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -21,6 +21,7 @@ import json
 import subprocess
 import argparse
 import platform
+import codecs
 
 import common
 
@@ -336,6 +337,14 @@ class StressTesterRunner(object):
                 os.remove(path)
             except OSError:
                 pass
+
+if os.isatty(sys.stdout.fileno()):
+    encoding = sys.stdout.encoding
+    errors = 'replace'
+else:
+    encoding = 'utf-8'
+    errors = None
+sys.stdout = codecs.getwriter(encoding)(sys.stdout, errors=errors)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
Hopefully fixes the below error due to trying to print '©' in the stress tester CI jobs:
> UnicodeEncodeError: 'ascii' codec can't encode character u'\xa9' in position 2673: ordinal not in range(128)