### PR TITLE
[sourcekit-stress-tester] Update sourcekit-xfails.json

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1090,20 +1090,10 @@
   },
   {
     "path" : "*\/Result\/Result\/Result.swift",
-    "applicableConfigs" : [
-      "master",
-      "swift-5.1-branch"
-    ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 722
-    }
-  },
-  {
-    "path" : "*\/Result\/Result\/Result.swift",
     "modification" : "concurrent-2375",
     "applicableConfigs" : [
+      "master",
+      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-8566",


### PR DESCRIPTION
Update `sourcekit-xfails.json` after https://github.com/apple/swift/pull/25912

rdar://problem/52386176