### PR TITLE
Update project_precommit_check with 5.1 configuration

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -86,6 +86,13 @@ supported_configs = {
                        'Target: x86_64-apple-darwin18.2.0\n',
             'description': 'Xcode 10.2 (contains Swift 5.0)',
             'branch': 'swift-5.0-branch'
+        },
+        '5.1': {
+            'version': 'Apple Swift version 5.1 '
+                       '(swiftlang-1100.0.212.5 clang-1100.0.28.2)\n'
+                       'Target: x86_64-apple-darwin18.2.0\n',
+            'description': 'Xcode 11 Beta 3 (contains Swift 5.1)',
+            'branch': 'swift-5.1-branch'
         }
     },
     # NOTE: Linux isn't fully supported yet


### PR DESCRIPTION
Update project_precommit_check with 5.1 configuration to the swiftlang that shipped in Xcode 11 Beta 3.