### PR TITLE
[run_sk_stress_test] Update sourcekit xfails for a stress-tester side fix

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1092,8 +1092,6 @@
     "path" : "*\/Result\/Result\/Result.swift",
     "modification" : "concurrent-2375",
     "applicableConfigs" : [
-      "master",
-      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-8566",
@@ -1106,8 +1104,6 @@
   {
     "path" : "*\/Result\/Result\/ResultProtocol.swift",
     "applicableConfigs" : [
-      "master",
-      "swift-5.1-branch",
       "swift-5.0-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371",


### PR DESCRIPTION
These were caused by a bug in the stress tester (fixed here: https://github.com/apple/swift-stress-tester/pull/76)