### PR TITLE
XFAIL R.swift and RxDataSources

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1868,7 +1868,23 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-11136",
+                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11136"
+              }
+            },
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-11136",
+                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11136"
+              }
+            }
+          }
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -2100,7 +2116,23 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "xfail": {
+          "compatibility": {
+            "4.2": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-11135",
+                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11135"
+              }
+            },
+            "5.0": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-11135",
+                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11135"
+              }
+            }
+          }
+        }
       }
     ]
   },


### PR DESCRIPTION
They're both seeing some issues with availability. XFAIL them to get the
bots running again.

rdar://53085717
rdar://53085707