### PR TITLE
Un-XFAIL SR-11135 and SR-11136

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1868,23 +1868,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-11135",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11135"
-              }
-            },
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-11135",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-11135"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"
@@ -2116,21 +2100,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-11136"
-              }
-            },
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-11136"
-              }
-            }
-          }
-        }
+        "configuration": "release"
       }
     ]
   },


### PR DESCRIPTION
Now that these bugs are fixed, we can reenable R.swift and RxDataSources.