### PR TITLE
add swift-nio-ssl

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2702,6 +2702,33 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-nio-ssl",
+    "path": "swift-nio-ssl",
+    "branch": "master",
+    "maintainer": "johannesweiss@apple.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "16de4b45c7cbe9815f995dd1539e6b7c4f0980a5"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/SwiftyJSON/SwiftyJSON.git",
     "path": "SwiftyJSON",
     "branch": "master",


### PR DESCRIPTION
I added this project in a separate build because it's slightly different
to the other repositories of the SwiftNIO family. Almost everything is
pure Swift but swift-nio-ssl contains a vendored (and symbol-prefixed)
version of BoringSSL.

I think it's a project that's very unlike most other Swift projects so I
think it's valuable but wanted to make it a separate PR.

### Pull Request Description

Replace with a description of this pull request. Instructions for adding
projects are available in the README.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [ ] be licensed with one of the following permissive licenses:
  * Apache 2 for the NIO and grpc bits
  * Combination ISC and OpenSSL license for BoringSSL
- [x] pass `./project_precommit_check` script run
