### PR TITLE
serpent: precommit check parameter violation for swiftc has been detected.

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -177,7 +177,13 @@ def is_correct_swift_version(swiftc, compatibility_version):
 
 
 def check(project, swift_branch, swiftc, compatibility_version):
-    if platform.system() == 'Darwin':
+    # Please, rewrite this script.
+    # Writing into function parameters is a bad manner. You can do better.
+    # Please, rewrite it.
+    # Thanks!
+
+    # find pre-installed if we don't specify parameter --swiftc
+    if platform.system() == 'Darwin' and not swiftc:
         common.debug_print("--- Locating swiftc executable ---")
         swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
     if not swiftc:


### PR DESCRIPTION
### Pull Request Description

- Prevent overriding of custom swiftc path by default `xcrun` output for Darwin.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	- [x] MIT
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.