### PR TITLE
[project_precommit_check] Add warning when passing --swiftc on Darwin

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -163,35 +163,40 @@ def is_correct_swift_version(swiftc, compatibility_version):
     except KeyError:
         common.debug_print("error: Project configured for unsupported platform or Swift version")
         raise
-    error_msg = "error: please select {description}".format(
-        description=supported_configs[platform.system()][compatibility_version]['description']
-    )
+
     if swift_version.split("\n")[0] != expected_swift_version.split("\n")[0]:
         common.debug_print("--- Version check failed ---")
         common.debug_print("Expected version:\n" + expected_swift_version)
         common.debug_print("Current version:\n" + swift_version)
-        common.debug_print(error_msg)
+        common.debug_print("warning: Unexpected swiftc version. "\
+            "Expected swiftc for Swift {compat_vers} can be found in {description}.".format(
+            description=supported_configs[platform.system()][compatibility_version]['description'],
+            compat_vers=compatibility_version)
+        )
         return False
     common.debug_print("--- Version check succeeded ---")
     return True
 
 
 def check(project, swift_branch, swiftc, compatibility_version):
-    if platform.system() == 'Darwin':
-        if swiftc:
-            common.debug_print("warning: disregarding passed swiftc in favor of currently selected swiftc.")
-        common.debug_print("--- Locating swiftc executable ---")
-        swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
+    xcrun_swiftc = None
     if not swiftc:
-        common.debug_print('error: please specify --swiftc for non-Darwin platforms.')
-        return 1
-    swiftc = os.path.abspath(swiftc)
-    if not is_correct_swift_version(swiftc, compatibility_version):
-        return 1
+        if platform.system() == 'Darwin':
+            common.debug_print("--- Locating swiftc executable ---")
+            xcrun_swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
+        else:
+            common.debug_print('error: please specify --swiftc for non-Darwin platforms.')
+            return 1
+
+    swiftc_path = os.path.abspath(xcrun_swiftc or swiftc)
+
+    if not is_correct_swift_version(swiftc_path, compatibility_version):
+        common.debug_print("warning: Continuing to build with unexpected swiftc version.\n")
+
     runner_command = [
         runner_path,
         '--swift-branch', swift_branch,
-        '--swiftc', swiftc,
+        '--swiftc', swiftc_path,
         '--projects', project_list,
         '--include-repos', 'path == "%s"' % project,
         '--include-versions', 'version == "%s"' % compatibility_version,

--- a/project_precommit_check
+++ b/project_precommit_check
@@ -178,10 +178,12 @@ def is_correct_swift_version(swiftc, compatibility_version):
 
 def check(project, swift_branch, swiftc, compatibility_version):
     if platform.system() == 'Darwin':
+        if swiftc:
+            common.debug_print("warning: disregarding passed swiftc in favor of currently selected swiftc.")
         common.debug_print("--- Locating swiftc executable ---")
         swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
     if not swiftc:
-        common.debug_print('error: please specify --swiftc')
+        common.debug_print('error: please specify --swiftc for non-Darwin platforms.')
         return 1
     swiftc = os.path.abspath(swiftc)
     if not is_correct_swift_version(swiftc, compatibility_version):

--- a/project_precommit_check
+++ b/project_precommit_check
@@ -163,7 +163,6 @@ def is_correct_swift_version(swiftc, compatibility_version):
     except KeyError:
         common.debug_print("error: Project configured for unsupported platform or Swift version")
         raise
-
     if swift_version.split("\n")[0] != expected_swift_version.split("\n")[0]:
         common.debug_print("--- Version check failed ---")
         common.debug_print("Expected version:\n" + expected_swift_version)
@@ -179,20 +178,16 @@ def is_correct_swift_version(swiftc, compatibility_version):
 
 
 def check(project, swift_branch, swiftc, compatibility_version):
-    xcrun_swiftc = None
     if not swiftc:
         if platform.system() == 'Darwin':
             common.debug_print("--- Locating swiftc executable ---")
-            xcrun_swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
+            swiftc = common.check_execute_output(['xcrun', '-f', 'swiftc']).strip()
         else:
             common.debug_print('error: please specify --swiftc for non-Darwin platforms.')
             return 1
-
-    swiftc_path = os.path.abspath(xcrun_swiftc or swiftc)
-
+    swiftc_path = os.path.abspath(swiftc)
     if not is_correct_swift_version(swiftc_path, compatibility_version):
         common.debug_print("warning: Continuing to build with unexpected swiftc version.\n")
-
     runner_command = [
         runner_path,
         '--swift-branch', swift_branch,


### PR DESCRIPTION
Allows `--swiftc` flag to be honored when passed to `project_precommit_check` on Darwin platforms. The version check must be relaxed for the this to work. Also provides relevant warnings that an unexpected swiftlang version is being used.