### PR TITLE
Remove unnecessary xfail for Kickstarter

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1144,36 +1144,14 @@
         "scheme": "ReactiveExtensions-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8270",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8270"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "ReactiveExtensions.xcodeproj",
         "scheme": "ReactiveExtensions-TestHelpers-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "3.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8270",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8270",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8270"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
3.0 configuration no longer exists, and the xfail is no longer needed.