### PR TITLE
Update Deferred project with 5.1 hash

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -518,12 +518,8 @@
     "branch": "master",
     "compatibility": [
       {
-        "version": "4.2",
-        "commit": "c374a6e7072ed88ed0c79299098ca2ba7c27e720"
-      },
-      {
-        "version": "5.0",
-        "commit": "c374a6e7072ed88ed0c79299098ca2ba7c27e720"
+        "version": "5.1",
+        "commit": "0ce7e57409a1dde7f26ec7d690bf87a4db22d71e"
       }
     ],
     "platforms": [
@@ -542,54 +538,21 @@
         "project": "Deferred.xcodeproj",
         "scheme": "MobileDeferred",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "Deferred.xcodeproj",
         "scheme": "TVDeferred",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectScheme",
         "project": "Deferred.xcodeproj",
         "scheme": "NanoDeferred",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-9899",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-9899"
-              }
-            }
-          }
-        }
+        "configuration": "Release"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-9899

This required project side changes, which appear to have been addressed. Adds a new 5.1 configuration, and removes the xfail from 4.2 and 5.0 configurations.

```
PASS: Deferred, 5.1, 0ce7e5, Swift Package
$ git -C project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 5.1, 0ce7e5, MobileDeferred, generic/platform=iOS
$ git -C project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 5.1, 0ce7e5, TVDeferred, generic/platform=tvOS
$ git -C project_cache/Deferred rev-parse --show-toplevel
PASS: Deferred, 5.1, 0ce7e5, NanoDeferred, generic/platform=watchOS
========================================
Action Summary:
     Passed: 4
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 4
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Deferred checked successfully against Swift 5.1 ---
```