### PR TITLE
Update exercism project configurations for Swift 5.1

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -722,16 +722,12 @@
     "repository": "Git",
     "url": "https://github.com/masters3d/xswift.git",
     "path": "exercism-xswift",
-    "branch": "do-not-delete-pre-4.2-compatibility",
+    "branch": "master",
     "maintainer": "cheyo@masters3d.com",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
-      },
-      {
-        "version": "4.1",
-        "commit": "7614aae4a87d92e2343473c619a805ace98a474e"
+        "version": "5.1",
+        "commit": "b640558479638d27c0a285aae617fc133296df20"
       }
     ],
     "platforms": [
@@ -739,29 +735,9 @@
     ],
     "actions": [
       {
-        "action": "BuildXcodeProjectTarget",
-        "project": "xswift.xcodeproj",
-        "target": "xswift",
-        "destination": "generic/platform=macOS",
-        "configuration": "Release",
-        "xfail": {
-          "compatibility": {
-            "4.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8307"
-              }
-            },
-            "4.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8307"
-              }
-            }
-          }
-        }
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit"
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -692,11 +692,11 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
+        "commit": "3df5e4ab83a9ab47228a46da7263e09a2a2b0b90"
       },
       {
         "version": "5.0",
-        "commit": "38a17de8717a2282fd4ff62cd1ce732b926bf4ab"
+        "commit": "3df5e4ab83a9ab47228a46da7263e09a2a2b0b90"
       },
       {
         "version": "5.1",
@@ -711,25 +711,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "4.2": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8307"
-              }
-            },
-            "5.0": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.0-branch": "https://bugs.swift.org/browse/SR-8307",
-                "swift-5.1-branch": "https://bugs.swift.org/browse/SR-8307"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -720,29 +720,6 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/masters3d/xswift.git",
-    "path": "exercism-xswift",
-    "branch": "master",
-    "maintainer": "cheyo@masters3d.com",
-    "compatibility": [
-      {
-        "version": "5.1",
-        "commit": "b640558479638d27c0a285aae617fc133296df20"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildSwiftPackage",
-        "configuration": "release",
-        "tags": "sourcekit"
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/vapor/fluent",
     "path": "fluent",
     "branch": "master",


### PR DESCRIPTION
[SR-8307](https://bugs.swift.org/browse/SR-8307) appears to be resolved by using newer project sources.

Updates the configuration for both `exercism-swift` and `exercism-xswift`.
