### PR TITLE
Remove xfail for RxSwift/RxCocoa

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2218,16 +2218,7 @@
         "scheme": "RxCocoa",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit",
-        "xfail": {
-          "compatibility": {
-            "5.1": {
-              "branch": {
-                "master": "https://bugs.swift.org/browse/SR-11141"
-              }
-            }
-          }
-        }
+        "tags": "sourcekit"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
https://bugs.swift.org/browse/SR-11136

Issue appears to be resolved as of Xcode 11 beta 5. Removes associated xfail.

```
$ ./runner.py --swift-branch master --swiftc /Applications/Xcodes/Xcode-11.0-beta-5.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects projects.json --include-repos 'path == "RxSwift"' --include-versions 'version == "5.1"' --include-actions 'action.startswith("Build")'
...
UPASS: https://bugs.swift.org/browse/SR-11141, RxSwift, 5.1, 70b8a3, RxCocoa, platform=macOS
```