### PR TITLE
Revert "Remove xfail for RxSwift/RxCocoa"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2119,7 +2119,16 @@
         "scheme": "RxCocoa",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit"
+        "tags": "sourcekit",
+        "xfail": {
+          "compatibility": {
+            "5.1": {
+              "branch": {
+                "master": "https://bugs.swift.org/browse/SR-11141"
+              }
+            }
+          }
+        }
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#372

Looks like this issue remains unfixed yet.