### PR TITLE
[run_sk_stress_test] Removed fixed stress tester xfail

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -260,7 +260,6 @@
       "offset" : 613
     },
     "applicableConfigs" : [
-      "master",
       "swift-5.1-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371"


### PR DESCRIPTION
The stress tester job is currently failing because of this: https://ci.swift.org/job/swift-master-sourcekitd-stress-tester/1120/