### PR TITLE
Add swift-futures

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2683,6 +2683,37 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/dfunckt/swift-futures",
+    "path": "swift-futures",
+    "branch": "master",
+    "maintainer": "akiskesoglou@gmail.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "68500e5501ca9986e996e16736496b5b2491af87"
+      },
+      {
+        "version": "5.1",
+        "commit": "68500e5501ca9986e996e16736496b5b2491af87"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/apple/swift-nio",
     "path": "swift-nio",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Adds swift-futures: https://github.com/dfunckt/swift-futures

Futures is a relatively large library, makes heavy use of value types and generics (which seem to be stressing the compiler quite a bit) and also includes a C target, which overall I think make for a valuable addition to the source compatibility suite.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift ~~4.0~~ 5.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.