### PR TITLE
[run_sk_stress_test] Remove fixed stress tester xfail in Dollar.swift

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -235,7 +235,6 @@
       "offset" : 1868
     },
     "applicableConfigs" : [
-      "master",
       "swift-5.1-branch"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-9371"


### PR DESCRIPTION
To get the stress tester CI job blue again:
  https://ci.swift.org/job/swift-master-sourcekitd-stress-tester/1128/