### PR TITLE
Install the parser library when running the stress tester

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -193,7 +193,7 @@ def build_swift_toolchain(workspace, args):
         '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
         '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
         '--llvm-install-components=libclang;libclang-headers',
-        '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
+        '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;parser-lib;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
         '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
         '--verbose-build',
         '--reconfigure',


### PR DESCRIPTION
Otherwise SwiftSyntax can't find it and the stress tester is unable to run. Should unblock the CI failure https://ci.swift.org/job/swift-master-sourcekitd-stress-tester/1392/.