### PR TITLE
Don't assume all xfailed actions have a 'configuration' specified

### DIFF
--- a/project.py
+++ b/project.py
@@ -361,9 +361,14 @@ def is_xfailed(xfail_args, compatible_version, platform, swift_branch, build_con
         current = {
             'compatibility': compatible_version,
             'branch': swift_branch,
-            'platform': platform,
-            'configuration': build_config.lower()
+            'platform': platform
         }
+        if 'configuration' in spec:
+          if build_config is None:
+            raise common.Unreachable("'xfail' entry contains 'configuration' "
+                "but none supplied via '--build-config' or the containing "
+                "action's 'configuration' field.")
+          current['configuration'] = build_config.lower()
         for key, value in current.iteritems():
           if key in spec and not is_or_contains(spec[key], value):
             return None

--- a/project_future.py
+++ b/project_future.py
@@ -396,9 +396,14 @@ def is_xfailed(xfail_args, compatible_version, platform, swift_branch, build_con
         current = {
             'compatibility': compatible_version,
             'branch': swift_branch,
-            'platform': platform,
-            'configuration': build_config.lower()
+            'platform': platform
         }
+        if 'configuration' in spec:
+          if build_config is None:
+            raise common.Unreachable("'xfail' entry contains 'configuration' "
+                "but none supplied via '--build-config' or the containing "
+                "action's 'configuration' field.")
+          current['configuration'] = build_config.lower()
         for key, value in current.iteritems():
           if key in spec and not is_or_contains(spec[key], value):
             return None


### PR DESCRIPTION
They only need it if they also have an xfail entry with a configuration field, and no overriding configuration was specified via the `--build-config` flag.