### PR TITLE
XFail Bow

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -271,7 +271,11 @@
         "project": "Bow.xcodeproj",
         "scheme": "Bow",
         "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "configuration": "Release",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-11740",
+            "branch": ["master"]
+        }
       },
       {
         "action": "TestXcodeProjectScheme",


### PR DESCRIPTION
For failure with `overriding declarations in extensions is not supported`. https://bugs.swift.org/browse/SR-11740