### PR TITLE
Revert "XFail Bow"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -271,11 +271,7 @@
         "project": "Bow.xcodeproj",
         "scheme": "Bow",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-            "issue": "https://bugs.swift.org/browse/SR-11740",
-            "branch": ["master"]
-        }
+        "configuration": "Release"
       },
       {
         "action": "TestXcodeProjectScheme",


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#394

Was fixed by https://github.com/apple/swift/pull/28206.