### PR TITLE
Update Swift 5.1 hash for CoreStore

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -413,7 +413,7 @@
       },
       {
         "version": "5.1",
-        "commit": "67bb9340c77c9b13624b44d3a6f559229e4f5b72"
+        "commit": "b4489301ac65dc36509583eb69731e8862fe0a20"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

Updated the Commit hash for CoreStore's Swift 5.1 support as the previous one had non-working Package.swift

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
