### PR TITLE
Use build-presets.ini presets in run_cperf's build-script invocation

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -182,72 +182,23 @@ def get_swiftc_path(instance, workspace, args):
 
 
 def build_swift_toolchain(workspace, args):
-    build_script_args_common = [
-        '--release',
-        '--no-assertions',
-        '--build-ninja',
-        '--llbuild',
-        '--swiftpm',
-        '--skip-build-benchmarks',
-    ]
-    if args.cmake_c_launcher:
-        build_script_args_common += ['--cmake-c-launcher={}'.format(args.cmake_c_launcher)]
-    if args.cmake_cxx_launcher:
-        build_script_args_common += ['--cmake-cxx-launcher={}'.format(args.cmake_cxx_launcher)]
     if platform.system() == 'Darwin':
-        build_command = [os.path.join(workspace, 'swift/utils/build-script')]
-        build_command += build_script_args_common
-        build_command += [
-            '--ios',
-            '--tvos',
-            '--watchos',
-            '--build-subdir=compat_macos',
-            '--compiler-vendor=apple',
-            '--',
-            '--darwin-install-extract-symbols',
-            '--darwin-toolchain-alias=swift',
-            '--darwin-toolchain-bundle-identifier=org.swift.compat-macos',
-            '--darwin-toolchain-display-name-short=Swift Development Snapshot'
-            '--darwin-toolchain-display-name=Swift Development Snapshot',
-            '--darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT',
-            '--darwin-toolchain-version=3.999.999',
-            '--install-llbuild',
-            '--install-swift',
-            '--install-swiftpm',
-            '--install-destdir={}/build/compat_macos/install'.format(workspace),
-            '--install-prefix=/toolchain/usr',
-            '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
-            '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
-            '--llvm-install-components=libclang;libclang-headers',
-            '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
-            '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
-            '--verbose-build',
-            '--reconfigure',
-        ]
+        platform_name = 'macos'
     elif platform.system() == 'Linux':
-        build_command = [os.path.join(workspace, 'swift/utils/build-script')]
-        build_command += build_script_args_common
-        build_command += [
-            '--foundation',
-            '--libdispatch',
-            '--xctest',
-            '--build-subdir=compat_linux',
-            '--',
-            '--install-foundation',
-            '--install-libdispatch',
-            '--install-llbuild',
-            '--install-swift',
-            '--install-swiftpm',
-            '--install-xctest',
-            '--install-destdir={}/build/compat_linux/install'.format(workspace),
-            '--install-prefix=/usr',
-            '--installable-package={}/build/compat_linux/root.tar.gz'.format(workspace),
-            '--swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license',
-            '--verbose-build',
-            '--reconfigure',
-        ]
+        platform_name = 'linux'
     else:
         raise common.UnsupportedPlatform
+
+    build_command = [
+        os.path.join(workspace, 'swift/utils/build-script'),
+        '--preset=cperf,platform={}'.format(platform_name),
+        'workspace={}'.format(workspace),
+    ]
+    
+    if args.cmake_c_launcher:
+        build_command += ['--cmake-c-launcher={}'.format(args.cmake_c_launcher)]
+    if args.cmake_cxx_launcher:
+        build_command += ['--cmake-cxx-launcher={}'.format(args.cmake_cxx_launcher)]
     
     # We do run this command for a dry run, but we pass through the flag.
     if args.dry_run:

--- a/run_cperf
+++ b/run_cperf
@@ -248,6 +248,11 @@ def build_swift_toolchain(workspace, args):
         ]
     else:
         raise common.UnsupportedPlatform
+    
+    # We do run this command for a dry run, but we pass through the flag.
+    if args.dry_run:
+        build_command += ['--dry-run']
+        
     common.check_execute(build_command, timeout=9999999)
 
 
@@ -320,9 +325,10 @@ def execute_runner(instance, workspace, configs, args):
             runner_command += get_sandbox_profile_flags()
         if args.verbose:
             runner_command += ["--verbose"]
+
         for i in range(args.repetitions):
             try:
-                common.check_execute(runner_command, timeout=9999999)
+                check_execute_if_not_dry_run(args, runner_command, timeout=9999999)
             except common.ExecuteCommandFailure:
                 pass
 
@@ -421,6 +427,14 @@ def find_module_statuses(configs, args):
     return (passed, failed)
 
 
+def check_execute_if_not_dry_run(args, command, **kwargs):
+    if args.dry_run:
+        print("Not executing: {}".format(runner_command))
+        return 0
+    else:
+        return common.execute(command, **kwargs)
+
+
 def analyze_results(configs, args):
     # Make a separate random run_id for each comment, to uniquify links.
     run_id = hex(random.randint(1, 2**63))[2:]
@@ -451,7 +465,7 @@ def analyze_results(configs, args):
             if os.path.exists(baseline)
             else [])
         returncodes.append(
-            common.execute(
+            check_execute_if_not_dry_run(args,
                 common_args +
                 ['--output', get_table_name('head', 'brief', variant),
                  '--divide-by', str(args.repetitions),
@@ -461,7 +475,7 @@ def analyze_results(configs, args):
                  '--delta-usec-thresh', delta_usec_thresh,
                  '--compare-stats-dirs', sd_old, sd_new]))
         returncodes.append(
-            common.execute(
+            check_execute_if_not_dry_run(args,
                 common_args +
                 select_stats_from_baseline_args +
                 ['--output', get_table_name('head', 'detailed', variant),
@@ -472,7 +486,7 @@ def analyze_results(configs, args):
                  '--compare-stats-dirs', sd_old, sd_new]))
         if args.show_baselines and os.path.exists(baseline):
             returncodes.append(
-                common.execute(
+                check_execute_if_not_dry_run(args,
                     common_args +
                     ['--output',
                      get_table_name('baseline', 'brief', variant),
@@ -483,7 +497,7 @@ def analyze_results(configs, args):
                      '--delta-usec-thresh', delta_usec_thresh,
                      '--compare-to-csv-baseline', baseline, sd_new]))
             returncodes.append(
-                common.execute(
+                check_execute_if_not_dry_run(args,
                     common_args +
                     ['--output',
                      get_table_name('baseline', 'detailed', variant),
@@ -631,6 +645,9 @@ def parse_args():
     parser.add_argument('--cmake-cxx-launcher',
                         metavar='PATH',
                         help='the absolute path to set CMAKE_CXX_COMPILER_LAUNCHER for build script')
+    parser.add_argument('--dry-run',
+                        action='store_true',
+                        help='clone compiler sources and simulate build-script run without building anything')
     return parser.parse_args()
 
 


### PR DESCRIPTION
Currently, the performance testing script hard-codes a long list of flags for its build-script invocation. This pull request changes it to instead use a new preset from build-presets.ini. This is a much cleaner solution that also allows us to test changes in build settings by editing the preset in a pull request.

This change won't fully function until the necessary presets are added to master; apple/swift#29515 does this. Once that change has landed, I will locally test that run_cperf runs correctly when building compilers in this way.