### PR TITLE
Move logs to project_cache directory

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -829,9 +829,11 @@ class ListBuilder(Factory):
                 finally:
                     if output_fd is not sys.stdout:
                         output_fd.close()
+                        log_basename = os.path.basename(log_filename)
+                        log_dirname = os.path.dirname(log_filename)
                         os.rename(
                             log_filename,
-                            '%s_%s' % (subbuilder_result, log_filename),
+                            log_dirname + os.path.sep + '%s_%s' % (subbuilder_result, log_basename),
                         )
 
         return results
@@ -870,9 +872,10 @@ class ProjectBuilder(ListBuilder):
 
 
 class VersionBuilder(ListBuilder):
-    def __init__(self, include, exclude, verbose, subbuilder, target, project):
+    def __init__(self, include, exclude, verbose, project_cache_path, subbuilder, target, project):
         super(VersionBuilder, self).__init__(include, exclude, verbose, subbuilder, target)
         self.project = project
+        self.project_cache_path = project_cache_path
 
     def included(self, subtarget):
         action = subtarget
@@ -900,6 +903,8 @@ class VersionBuilder(ListBuilder):
         log_filename = re.sub(
             r"[^\w\_\.]+", "-", identifier
         ).strip('-').strip('_') + '.log'
+
+        log_filename = self.project_cache_path + os.path.sep + log_filename
         if self.verbose:
             fd = sys.stdout
         else:

--- a/project_future.py
+++ b/project_future.py
@@ -900,6 +900,8 @@ class VersionBuilder(ListBuilder):
             ([scheme_target] if scheme_target else []) +
             ([destination] if destination else [])
         )
+        if not os.path.exists(self.project_cache_path):
+            common.check_execute(['mkdir', '-p', self.project_cache_path])
         log_filename = re.sub(
             r"[^\w\_\.]+", "-", identifier
         ).strip('-').strip('_') + '.log'

--- a/runner.py
+++ b/runner.py
@@ -50,6 +50,7 @@ def main():
                 args.include_actions,
                 args.exclude_actions,
                 args.verbose,
+                args.project_cache_path,
                 project_future.CompatActionBuilder.factory(
                     args.swiftc,
                     args.swift_version,


### PR DESCRIPTION
Useful while building source-combat-suite simultaneously with different swift compilers using --project-cache-path option
