### PR TITLE
Add flag to xcodebuild to disable manifest sandbox

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -317,7 +317,8 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
             action['action']
         )
 
-        initial_xcodebuild_flags = ['SWIFT_EXEC=%s' % swiftc]
+        initial_xcodebuild_flags = ['SWIFT_EXEC=%s' % swiftc,
+                                    '-IDEPackageSupportDisableManifestSandbox=YES']
 
         if build_config == 'debug':
             initial_xcodebuild_flags += ['-configuration', 'Debug']


### PR DESCRIPTION
We're seeing a collision in some sandbox rules. Since we're using our own sandbox in the source compat suite, we can disable the one coming from package support.

For now, this will add `-IDEPackageSupportDisableManifestSandbox=YES` to each invocation of xcodebuild, which should be a no-op for non-package projects, and would likely be the right thing to do for all package projects.

rdar://53518566