### PR TITLE
[cperf] Change cperf to use source compat preset to ensure.

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -181,70 +181,59 @@ def get_swiftc_path(instance, workspace, args):
     return swiftc_path
 
 
+def get_preset_name(args):
+    platform_name = None
+    if platform.system() == 'Darwin':
+        platform_name = 'macos'
+    elif platform.system() == 'Linux':
+        platform_name = 'linux'
+    else:
+        raise common.UnsupportedPlatform
+    assert(platform_name is not None)
+
+    build_type = ''
+    if args.debug:
+        build_type = build_type + 'D'
+    else:
+        build_type = build_type + 'R'
+
+    if args.assertions:
+        build_type = build_type + 'A'
+
+    preset = 'source_compat_suite_%s_%s'
+    return preset % (platform_name, build_type)
+
+
 def build_swift_toolchain(workspace, args):
+    build_script_preset = get_preset_name(args)
+
     build_script_args_common = [
-        '--release',
-        '--no-assertions',
-        '--build-ninja',
-        '--llbuild',
-        '--swiftpm',
-        '--skip-build-benchmarks',
+        '--preset=%s' % build_script_preset
     ]
+
+    if args.distcc:
+        build_script_args_common += ['--distcc']
     if args.cmake_c_launcher:
         build_script_args_common += ['--cmake-c-launcher={}'.format(args.cmake_c_launcher)]
     if args.cmake_cxx_launcher:
         build_script_args_common += ['--cmake-cxx-launcher={}'.format(args.cmake_cxx_launcher)]
+
+    build_command = [os.path.join(workspace, 'swift/utils/build-script')]
+    build_command += build_script_args_common
+
     if platform.system() == 'Darwin':
-        build_command = [os.path.join(workspace, 'swift/utils/build-script')]
-        build_command += build_script_args_common
         build_command += [
-            '--ios',
-            '--tvos',
-            '--watchos',
-            '--build-subdir=compat_macos',
-            '--compiler-vendor=apple',
-            '--',
-            '--darwin-install-extract-symbols',
-            '--darwin-toolchain-alias=swift',
-            '--darwin-toolchain-bundle-identifier=org.swift.compat-macos',
-            '--darwin-toolchain-display-name-short=Swift Development Snapshot'
-            '--darwin-toolchain-display-name=Swift Development Snapshot',
-            '--darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT',
-            '--darwin-toolchain-version=3.999.999',
-            '--install-llbuild',
-            '--install-swift',
-            '--install-swiftpm',
-            '--install-destdir={}/build/compat_macos/install'.format(workspace),
-            '--install-prefix=/toolchain/usr',
-            '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
-            '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
-            '--llvm-install-components=libclang;libclang-headers',
-            '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
-            '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
-            '--verbose-build',
-            '--reconfigure',
+            'install_destdir={}/build/compat_macos/install'.format(workspace),
+            'install_prefix=/toolchain/usr',
+            'install_symroot={}/build/compat_macos/symroot'.format(workspace),
+            'installable_package={}/build/compat_macos/root.tar.gz'.format(workspace),
+            'symbols_package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
         ]
     elif platform.system() == 'Linux':
-        build_command = [os.path.join(workspace, 'swift/utils/build-script')]
-        build_command += build_script_args_common
         build_command += [
-            '--foundation',
-            '--libdispatch',
-            '--xctest',
-            '--build-subdir=compat_linux',
-            '--',
-            '--install-foundation',
-            '--install-libdispatch',
-            '--install-llbuild',
-            '--install-swift',
-            '--install-swiftpm',
-            '--install-xctest',
-            '--install-destdir={}/build/compat_linux/install'.format(workspace),
-            '--install-prefix=/usr',
-            '--installable-package={}/build/compat_linux/root.tar.gz'.format(workspace),
-            '--swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;license',
-            '--verbose-build',
-            '--reconfigure',
+            'install_destdir={}/build/compat_linux/install'.format(workspace),
+            'install_prefix=/usr',
+            'installable_package={}/build/compat_linux/root.tar.gz'.format(workspace),
         ]
     else:
         raise common.UnsupportedPlatform


### PR DESCRIPTION
This beyond making it easier to maintain this over time, also (due to the preset
already doing this) solves an issue where the compiler perf suite couldn't build
swiftpm since it was not installing dsymutil into the just installed toolchain.
