### PR TITLE
Add CareKit to the projects list

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -283,6 +283,37 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/carekit-apple/CareKit.git",
+    "path": "CareKit",
+    "branch": "master",
+    "maintainer": "erik_h@apple.com",
+    "compatibility": [
+      {
+        "version": "5.1",
+        "commit": "f5cbdc9ef0139b53b18ca0921133486ac242e22e"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildXcodeWorkspaceScheme",
+        "workspace": "CKWorkspace.xcworkspace",
+        "scheme": "CareKit",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "TestXcodeWorkspaceScheme",
+        "workspace": "CKWorkspace.xcworkspace",
+        "scheme": "CareKit",
+        "destination": "platform=iOS Simulator,name=iPhone 11 Pro Max"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/badoo/Chatto.git",
     "path": "Chatto",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description
This PR adds [CareKit](https://github.com/carekit-apple/CareKit) to the source compatibility suite.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 5.2 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run