### PR TITLE
Added SwiftPM build of Siesta

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3284,16 +3284,12 @@
   {
     "repository": "Git",
     "url": "https://github.com/bustoutsolutions/siesta.git",
-    "path": "siesta",
+    "path": "siesta-legacy",
     "branch": "master",
     "compatibility": [
       {
         "version": "4.0",
         "commit": "926127231446fc5c1c8c3236033914a4006ab9a2"
-      },
-      {
-        "version": "5.1",
-        "commit": "3847e03570cafb0e40fe0fad6d89d04fb98cfabe"
       }
     ],
     "maintainer": "cantrell@pobox.com",
@@ -3336,7 +3332,7 @@
   {
     "repository": "Git",
     "url": "https://github.com/bustoutsolutions/siesta.git",
-    "path": "siesta-swiftpm",
+    "path": "siesta",
     "branch": "master",
     "compatibility": [
       {
@@ -3349,6 +3345,36 @@
       "Darwin"
     ],
     "actions": [
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Siesta.xcodeproj",
+        "target": "Siesta iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Siesta.xcodeproj",
+        "target": "Siesta macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Siesta.xcodeproj",
+        "target": "SiestaUI iOS",
+        "destination": "generic/platform=iOS",
+        "configuration": "Release"
+      },
+      {
+        "action": "BuildXcodeProjectTarget",
+        "project": "Siesta.xcodeproj",
+        "target": "SiestaUI macOS",
+        "destination": "generic/platform=macOS",
+        "configuration": "Release",
+        "tags": "sourcekit"
+      },
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",

--- a/projects.json
+++ b/projects.json
@@ -3335,6 +3335,32 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/bustoutsolutions/siesta.git",
+    "path": "siesta-swiftpm",
+    "branch": "master",
+    "compatibility": [
+      {
+        "version": "5.1",
+        "commit": "cb9c1bf6dbb89028798b9179fe4d1e1762586057"
+      }
+    ],
+    "maintainer": "cantrell@pobox.com",
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/vapor/console.git",
     "path": "vapor_console",
     "branch": "master",


### PR DESCRIPTION
TL;DR: Attempting to add SwiftPM tests only for the newest version of Siesta, but preserve the existing Xcode-only config for older versions. Is this PR the proper way to accomplish that?

---

Siesta has been in the compatibility suite since the suite’s earliest days, as an Xcode-only project.

Siesta’s test suite depends on Quick and Nimble. When building as an Xcode project, Carthage manages those dependences, and swift-source-compat-suite thus can’t run the tests. However, at long last, I got Siesta working with SwiftPM (yay!), and now swift-source-compat-suite is capable of running Siesta’s tests via SwiftPM.

There is value in adding those tests to your suite, I think: there are some quirks in them you probably want in your regression tests. (In fact, as of last week, Siesta’s tests exposed a regression in the current dev snapshot.)

**BUT** only the very latest release of Siesta supports SwiftPM. I thus want to configure `BuildSwiftPackage` and `TestSwiftPackage` only for the latest releases, while still having the older ones run Xcode-only. My solution (in this PR) is to list Siesta twice with two different `path`s pointing at the same GitHub repo:

- one (already in the compat suite) configured to build only with Xcode, and pointing at both new & old versions of Siesta, and
- one (added in this PR) configured to build only with SwiftPM, and pointing only at the newer version of Siesta.

Does that make sense? Is there a better way?