### PR TITLE
Use built libraries when running SPM builds.

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -209,6 +209,7 @@ def build_swift_package(path, swiftc, configuration, sandbox_profile,
         clean_swift_package(path, swiftc, sandbox_profile,
                             stdout=stdout, stderr=stderr)
     env = os.environ
+    env['DYLD_LIBRARY_PATH'] = get_stdlib_platform_path(swiftc, 'macOS')
     env['SWIFT_EXEC'] = swiftc
     command = [swift, 'build', '-C', path, '--verbose',
                '--configuration', configuration]


### PR DESCRIPTION
The SPM that is being used to build projects is the just built SPM.  Consequently, it may depend on changes present in the just-built libraries but absent from the libraries in the OS.

Here, those just built libraries are used by SPM by setting DYLD_LIBRARY_PATH to the directory of just built macosx libraries in the environment in which swift build is run.