### PR TITLE
Update hash for Base64CoderSwiftUI

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3718,12 +3718,7 @@
         "target": "Base64CoderSwiftUI",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke",
-        "xfail": {
-          "issue": "https://bugs.swift.org/browse/SR-11350",
-          "compatibility": "5.1",
-          "branch": ["master", "swift-5.1-branch", "swift-5.2-branch"]
-        }
+        "tags": "sourcekit sourcekit-smoke"
       }
     ]
   },

--- a/projects.json
+++ b/projects.json
@@ -3705,7 +3705,7 @@
     "compatibility": [
       {
         "version": "5.1",
-        "commit": "bd103d79396e16446056d2e571849e6c26faa6c1"
+        "commit": "f94c86027607f411e1b2e2f7373df375dc0173d6"
       }
     ],
     "platforms": [


### PR DESCRIPTION
Base64CoderSwiftUI is currently xfailed, due to the following [failure](https://ci.swift.org/job/swift-master-source-compat-suite/5010/artifact/swift-source-compat-suite/XFAIL_Base64CoderSwiftUI-Base64CoderSwiftUI.xcodeproj_5.1_BuildXcodeProjectTarget_Base64CoderSwiftUI_generic-platform-iOS.log)...
```
/Users/buildnode/jenkins/workspace/swift-master-source-compat-suite/swift-source-compat-suite/project_cache/Base64CoderSwiftUI/Base64CoderSwiftUI/Model.swift:169:24: error: cannot find type 'BindableObject' in scope
class PublishersModel: BindableObject {
                       ^~~~~~~~~~~~~~
```

The newest commit may address this failure on the project side.