### PR TITLE
[runner.py] Fix args passed via --add-xcodebuild-flags not being concatenated properly

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -40,7 +40,7 @@ def main():
     # DISABLED DUE TO: rdar://59302454.
     # To track removing this line: rdar://59302467.
     xcodebuild_flags = args.add_xcodebuild_flags
-    xcodebuild_flags += 'DEBUG_INFORMATION_FORMAT=dwarf'
+    xcodebuild_flags += (' ' if xcodebuild_flags else '') + 'DEBUG_INFORMATION_FORMAT=dwarf'
 
     index = json.loads(open(args.projects).read())
     result = project_future.ProjectListBuilder(

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1,5 +1,27 @@
 [
   {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/packages\/UI\/Sources\/UI\/ItemImage.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 600
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12973"
+  },
+  {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/env\/UIState.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 771
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12959"
+  },
+  {
     "path" : "*\/Alamofire\/Source\/Result.swift",
     "applicableConfigs" : [
       "master",
@@ -22,7 +44,7 @@
       "master",
       "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/AMScrollingNavbar\/Source\/ScrollingNavigationController.swift",
@@ -34,7 +56,7 @@
       "master",
       "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/AsyncNinja\/Sources\/BaseProducer.swift",
@@ -145,7 +167,7 @@
       "master",
       "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Chatto\/ChattoAdditions\/Source\/Chat Items\/BaseMessage\/BaseMessageViewModel.swift",
@@ -226,7 +248,7 @@
       "master",
       "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Dollar\/Sources\/Dollar.swift",
@@ -242,14 +264,15 @@
   {
     "path" : "*\/Dollar\/Sources\/Dollar.swift",
     "issueDetail" : {
-      "kind" : "stressTesterCrash",
-      "arguments" : "--format json --page 30\/63 --rewrite-mode concurrent --limit 1000 --request CursorInfo --request RangeInfo --request CodeComplete --request CollectExpressionType *\/Dollar\/Sources\/Dollar.swift*"
+      "kind" : "rangeInfo",
+      "length" : 5,
+      "offset" : 8423
     },
     "applicableConfigs" : [
       "master",
-      "release/5.3"
+      "release\/5.3"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-11908"
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12957"
   },
   {
     "path" : "*\/Dollar\/Sources\/Dollar.swift",
@@ -261,6 +284,64 @@
       "kind" : "codeComplete",
       "offset" : 2423
     }
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/Packages\/UI\/Sources\/UI\/badges\/PopularityBadge.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 280
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12959"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/Packages\/UI\/Sources\/UI\/badges\/PopularityBadge.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1000
+    },
+    "applicableConfigs" : [
+      "release\/5.3"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12960"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/Packages\/Backend\/Sources\/Backend\/preferences\/AppUserDefaults.swift",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 113,
+      "offset" : 209
+    },
+    "applicableConfigs" : [
+      "master",
+      "release\/5.3"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12958"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/launch\/AppDelegate.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 160
+    },
+    "applicableConfigs" : [
+      "release\/5.3"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/pull/32281 (fixed on master)"
+  },
+  {
+    "path" : "*\/Base64CoderSwiftUI\/Base64CoderSwiftUI\/ContentView.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 304
+    },
+    "applicableConfigs" : [
+      "master",
+      "release\/5.3"
+    ],
+    "issueUrl" : "https://bugs.swift.org/browse/SR-12965"
   },
   {
     "path" : "*\/DNS\/Sources\/DNS\/Types.swift",
@@ -282,10 +363,20 @@
       "offset" : 1027
     },
     "applicableConfigs" : [
-      "master",
-      "release/5.3"
+      "release\/5.3"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-12690"
+  },
+  {
+    "path" : "*\/DNS\/Sources\/DNS\/IP.swift",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 903
+    },
+    "applicableConfigs" : [
+      "master"
+    ],
+    "issueUrl" : "<issue url>"
   },
   {
     "path" : "*\/DNS\/Sources\/DNS\/Bytes.swift",
@@ -331,7 +422,7 @@
     "applicableConfigs" : [
       "master"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Deferred\/Sources\/Deferred\/DeferredQueue.swift",
@@ -357,7 +448,7 @@
       "master",
       "swift-5.1-branch"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-9371",
+    "issueUrl" : "https://bugs.swift.org/browse/SR-9371"
   },
   {
     "path" : "*\/Deferred\/Sources\/Task\/ResultRecovery.swift",
@@ -1130,7 +1221,7 @@
     },
     "applicableConfigs" : [
       "master",
-      "release/5.3"
+      "release\/5.3"
     ],
     "issueUrl" : "https://bugs.swift.org/browse/SR-12282"
   },


### PR DESCRIPTION
They were being concatenated without adding a leading space to separate them
from the preceding arguments, breaking some project builds in the stress tester CI jobs (which pass extra xcodebuild flags).

Also updates the xfails for run_sk_stress_test now that the broken projects are building, and for some recent fixes.