### PR TITLE
Xfailed a number of projects.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -792,7 +792,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -1210,7 +1215,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["4.0", "5.1"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -1391,7 +1401,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": "5.1",
+            "branch": "master"
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -2427,7 +2442,19 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": [
+            {
+                "issue": "https://bugs.swift.org/browse/SR-13190",
+                "compatibility": "5.1",
+                "branch": "master"
+            },
+            {
+                "issue": "https://bugs.swift.org/browse/SR-13189",
+                "compatibility": "4.0",
+                "branch": "master"
+            }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -2485,7 +2512,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": "5.1",
+            "branch": "master"
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -2721,7 +2753,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.1", "5.0", "4.2", "4.0"],
+            "branch": "master"
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -3400,7 +3437,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": "5.1",
+            "branch": "master"
+        }
       },
       {
         "action": "TestSwiftPackage"
@@ -3435,7 +3477,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -3495,7 +3542,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -3527,7 +3579,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.1", "5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -3559,7 +3616,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -3591,7 +3653,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },
@@ -3623,7 +3690,12 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13189",
+            "compatibility": ["5.1", "5.0", "4.2"],
+            "branch": "master"
+        }
       }
     ]
   },


### PR DESCRIPTION
The following projects/configurations were xfailed:
    fluent, 5.0, Swift Package
    fluent, 4.2, Swift Package
    Kitura, 5.1, Swift Package
    Kitura, 4.0, Swift Package
    Moya, 5.1, Swift Package
    SRP, 5.1, Swift Package
    SRP, 4.0, Swift Package
    Sourcery, 5.1, Swift Package
    SwiftLint, 5.1, Swift Package
    SwiftLint, 5.0, Swift Package
    SwiftLint, 4.2, Swift Package
    SwiftLint, 4.0, Swift Package
    siesta, 5.1, Swift Package
    vapor_console, 5.0, Swift Package
    vapor_console, 4.2, Swift Package
    vapor_database-kit, 5.0, Swift Package
    vapor_database-kit, 4.2, Swift Package
    vapor_multipart, 5.1, Swift Package
    vapor_multipart, 5.0, Swift Package
    vapor_multipart, 4.2, Swift Package
    vapor_routing, 5.0, Swift Package
    vapor_routing, 4.2, Swift Package
    vapor_service, 5.0, Swift Package
    vapor_service, 4.2, Swift Package
    vapor_template-kit, 5.1, Swift Package
    vapor_template-kit, 5.0, Swift Package
    vapor_template-kit, 4.2, db35b1, Swift Package

The failure of

    SRP, 5.1, Swift Package

is tracked by

    https://bugs.swift.org/browse/SR-13190

All other failures are tracked by

    https://bugs.swift.org/browse/SR-13189