### PR TITLE
Xfail ACHNBrowserUI, 5.1, generic/platform=iOS.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -21,7 +21,13 @@
         "target": "ACHNBrowserUI",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit sourcekit-smoke",
+        "xfail": {
+            "issue": "https://bugs.swift.org/browse/SR-13197",
+            "compatibility": "5.1",
+            "branch": "master",
+            "configuration": "debug"
+        }
       }
     ]
   },


### PR DESCRIPTION
Example of failure:

    https://ci.swift.org/view/Dashboard/job/swift-master-source-compat-suite-debug/3301/consoleText