### PR TITLE
Update RxReactiveObjC to use Swift PM

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2269,16 +2269,28 @@
     "repository": "Git",
     "url": "https://github.com/igor-makarov/RxReactiveObjC.git",
     "path": "RxReactiveObjC",
-    "branch": "comitted-pods-for-swift-compat",
+    "branch": "main",
     "maintainer": "igormaka@gmail.com",
     "compatibility": [
       {
+        "version": "4.2",
+        "commit": "ec478bb68edbb8f10a7982bcffe9f1779de4e58b"
+      },
+      {
         "version": "5.0",
-        "commit": "580693f3e60dc0c6219cd82cbae651f518940a7f"
+        "commit": "ec478bb68edbb8f10a7982bcffe9f1779de4e58b"
       },
       {
         "version": "5.1",
-        "commit": "580693f3e60dc0c6219cd82cbae651f518940a7f"
+        "commit": "ec478bb68edbb8f10a7982bcffe9f1779de4e58b"
+      },
+      {
+        "version": "5.2",
+        "commit": "ec478bb68edbb8f10a7982bcffe9f1779de4e58b"
+      },
+      {
+        "version": "5.3",
+        "commit": "ec478bb68edbb8f10a7982bcffe9f1779de4e58b"
       }
     ],
     "platforms": [
@@ -2286,18 +2298,11 @@
     ],
     "actions": [
       {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "RxReactiveObjC.xcworkspace",
-        "scheme": "RxReactiveObjCSwiftCompat",
-        "destination": "generic/platform=iOS",
-        "configuration": "Release"
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
       },
       {
-        "action": "TestXcodeWorkspaceScheme",
-        "workspace": "RxReactiveObjC.xcworkspace",
-        "scheme": "RxReactiveObjCSwiftCompat",
-        "destination": "platform=iOS Simulator,name=iPhone 7",
-        "configuration": "Debug"
+        "action": "TestSwiftPackage"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description

The library `RxReactiveObjC` is already in the suite. 


I've recently made the library to support Swift Package Manager.  
This way of integration is better as the previous one was using a special branch to work around the fact that the compat suite doesn't support CocoaPods.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* MIT
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
