### PR TITLE
Revert "XFAIL Kickstarter and ReactiveSwift targets affected by SR-13…

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1113,14 +1113,7 @@
         "scheme": "Prelude-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -1128,14 +1121,7 @@
         "scheme": "Prelude-UIKit-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       }
     ]
   },
@@ -1165,14 +1151,7 @@
         "scheme": "ReactiveExtensions-iOS",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0", "5.1"],
-            "branch": "master"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -2224,56 +2203,28 @@
         "scheme": "ReactiveSwift-macOS",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-tvOS",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "ReactiveSwift.xcworkspace",
         "scheme": "ReactiveSwift-watchOS",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://bugs.swift.org/browse/SR-13548",
-            "compatibility": ["4.0"],
-            "branch": "master"
-          }
-        ]
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
…548"

With https://github.com/apple/swift/pull/33946 and https://github.com/apple/swift/pull/33955 applied, I no longer see any !hasValidInsertionPoint assertion failures when building the source compat suite locally.