### PR TITLE
Revert "Xfail siesta and siesta-legacy"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3419,12 +3419,7 @@
         "project": "Siesta.xcodeproj",
         "target": "SiestaUI iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-            "issue": "https://bugs.swift.org/browse/SR-13623",
-            "compatibility": "4.0",
-            "branch": "main"
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",
@@ -3472,12 +3467,7 @@
         "project": "Siesta.xcodeproj",
         "target": "SiestaUI iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": {
-            "issue": "https://bugs.swift.org/browse/SR-13623",
-            "compatibility": "5.1",
-            "branch": "main"
-        }
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeProjectTarget",


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#460. These should have been fixed by https://github.com/apple/swift/pull/34102.