### PR TITLE
Build Evergreen 4.0 x86_64 only

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -747,7 +747,7 @@
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Evergreen.xcworkspace",
         "scheme": "Evergreen",
-        "destination": "generic/platform=macOS",
+        "destination": "generic/platform=macOS,arch=x86_64",
         "configuration": "Release",
         "tags": "sourcekit-disabled"
       }

--- a/projects.json
+++ b/projects.json
@@ -747,7 +747,10 @@
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Evergreen.xcworkspace",
         "scheme": "Evergreen",
-        "destination": "generic/platform=macOS,arch=x86_64",
+        "destination": "generic/platform=macOS",
+        "environment": {
+            "ARCHS": "x86_64"
+        },
         "configuration": "Release",
         "tags": "sourcekit-disabled"
       }


### PR DESCRIPTION
This addresses the Source Compatibility Suite failure

```
error: The linked and embedded framework 'Sparkle.framework' is missing
one or more architectures required by this target: arm64. (in target
'Evergreen' from project 'Evergreen')
```

Addresses rdar://70533579