### PR TITLE
Un-XFAIL ACHNBrowserUI in debug configuration (main branch)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -24,12 +24,6 @@
         "tags": "sourcekit sourcekit-smoke",
         "xfail": [
             {
-                "issue": "https://bugs.swift.org/browse/SR-13197",
-                "compatibility": "5.1",
-                "branch": "main",
-                "configuration": "debug"
-            },
-            {
                 "issue": "https://bugs.swift.org/browse/SR-13198",
                 "compatibility": "5.1",
                 "branch": "release/5.3",


### PR DESCRIPTION
Debug builds are UPASS'ing on main right now - https://ci.swift.org/view/Source%20Compatibility/job/swift-main-source-compat-suite-debug/3600/artifact/swift-source-compat-suite/