### PR TITLE
Un-XFAIL ACHNBrowserUI in debug configuration (5.3 branch)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -21,15 +21,7 @@
         "target": "ACHNBrowserUI",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke",
-        "xfail": [
-            {
-                "issue": "https://bugs.swift.org/browse/SR-13198",
-                "compatibility": "5.1",
-                "branch": "release/5.3",
-                "configuration": "debug"
-            }
-        ]
+        "tags": "sourcekit sourcekit-smoke"
       }
     ]
   },


### PR DESCRIPTION
ACHNBrowserUI is UPASSing for 5.3: https://ci.swift.org/job/swift-5.3-master-source-compat-suite-debug//302/console