### PR TITLE
Add --filter-by-tag to run script and "swiftpm" tag to relevant project actions

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -197,7 +197,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -227,7 +228,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "debug",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage",
@@ -592,7 +593,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit sourcekit-smoke swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -619,7 +620,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "BuildXcodeProjectScheme",
@@ -765,7 +766,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -795,7 +796,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -826,7 +827,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -857,7 +858,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit sourcekit-smoke swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -891,7 +892,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1208,7 +1210,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -1271,7 +1273,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1301,7 +1304,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1389,7 +1392,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1420,7 +1423,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1474,7 +1477,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1525,7 +1529,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1634,7 +1639,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1669,7 +1675,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -1714,7 +1720,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestXcodeProjectScheme",
@@ -1763,7 +1770,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -1918,7 +1925,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2130,7 +2137,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2217,7 +2225,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit sourcekit-smoke swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2246,7 +2254,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       }
     ]
   },
@@ -2441,7 +2450,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled",
+        "tags": "sourcekit-disabled swiftpm",
         "xfail": [
             {
                 "issue": "https://bugs.swift.org/browse/SR-13190",
@@ -2483,7 +2492,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -2506,7 +2515,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2691,7 +2700,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -2727,7 +2736,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2827,7 +2836,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2862,7 +2871,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2889,7 +2898,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2920,7 +2929,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -2947,7 +2956,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -3117,7 +3126,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -3151,7 +3161,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -3302,7 +3312,8 @@
       },
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -3406,7 +3417,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"
@@ -3441,7 +3452,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3473,7 +3484,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3501,7 +3512,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3533,7 +3544,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3565,7 +3576,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3597,7 +3608,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3629,7 +3640,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3661,7 +3672,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3693,7 +3704,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled"
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },
@@ -3741,7 +3752,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"

--- a/run
+++ b/run
@@ -62,6 +62,9 @@ def parse_args():
     parser.add_argument("--debug",
                         help='Build Swift in debug mode',
                         action='store_true')
+    parser.add_argument("--filter-by-tag",
+                        metavar='TAG',
+                        help='Only run project actions with the given tag')
     parser.add_argument("--test",
                         help='Only run test actions',
                         action='store_true')
@@ -162,6 +165,8 @@ def execute_runner(workspace, args):
     swiftc_path = get_swiftc_path(workspace, args.swiftc)
     if args.test:
         action_filter = 'action.startswith("TestSwiftPackage")'
+    elif args.filter_by_tag:
+        action_filter = '"tags" in locals() and "{}" in tags.split()'.format(args.filter_by_tag)
     else:
         action_filter = 'action.startswith("Build")'
     runner_command = [


### PR DESCRIPTION
This pull request does two things in support of a future Swift Package Manager-specific compatibility test mode:

### Add `swiftpm` tags to relevant build project actions

All existing projects with `BuildSwiftPackage` actions now also have a "swiftpm" tag added to those actions. This will control what gets run for SwiftPM compatibility testing and I imagine it should work similarly to how the sourcekit stuff is used now:

- New projects opt in by adding the "swiftpm" tag.
- Projects are temporarily disabled by switching to the "swiftpm-disabled" tag.
- Existing projects that have been opted-in can choose not to participate by removing the tag entirely.

I'm not set on "swiftpm" as the name of this tag, but it's concise and consistent with existing build flags. 

### Add `--filter-by-tag` argument to `run` script

This brings the `--filter-by-tag` argument [from the sourcekit script](https://github.com/apple/swift-source-compat-suite/blob/8d5519c53f8a340f3269ce8d61717d3906c545e9/run_sk_stress_test#L65-L68) to the `run` script. An example invocation would look like: `./run swiftBranchName --filter-by-tag swiftpm --swiftc /path/to/swiftc`

@shahmishal, this isn't quite what we discussed (which was duplicating one of the existing run scripts and adapting that for SwiftPM), but I'm hoping that this approach can co-exist with current functionality. My initial investigation makes this seem tenable (at least as far as SwiftPM is concerned), but perhaps there's some flaw I'm not seeing.

/cc @tomerd @neonichu @abertelrud 