### PR TITLE
Add swift-argument-parser

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2639,7 +2639,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -2623,6 +2623,31 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-argument-parser",
+    "path": "swift-argument-parser",
+    "branch": "main",
+    "maintainer": "natecook@apple.com",
+    "compatibility": [
+      {
+        "version": "5.2",
+        "commit": "41f5fe52a34b2c7b9938996387fabfaca21918bd"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/malcommac/SwiftDate",
     "path": "SwiftDate",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Add https://github.com/apple/swift-argument-parser

### Acceptance Criteria
- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run
```
PASS: swift-argument-parser, 5.2, 41f5fe, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- swift-argument-parser checked successfully against Swift 5.2 ---
```