### PR TITLE
add swift-log

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2882,7 +2882,7 @@
     "repository": "Git",
     "url": "https://github.com/apple/swift-log",
     "path": "swift-log",
-    "branch": "master",
+    "branch": "main",
     "maintainer": "ktoso@apple.com",
     "compatibility": [
       {

--- a/projects.json
+++ b/projects.json
@@ -2880,6 +2880,37 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-log",
+    "path": "swift-log",
+    "branch": "master",
+    "maintainer": "ktoso@apple.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "16cfcc60e49d940c93367e5fe0e0533bd27e9733"
+      },
+      {
+        "version": "5.2",
+        "commit": "16cfcc60e49d940c93367e5fe0e0533bd27e9733"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/apple/swift-nio-http2",
     "path": "swift-nio-http2",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Add swift-log to the suite.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
  - 5.0+
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run

```
PASS: swift-log, 5.2, 16cfcc, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- swift-log checked successfully against Swift 5.2 ---
```
