### PR TITLE
add swift cluster membership

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3373,6 +3373,33 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-cluster-membership",
+    "path": "swift-cluster-membership",
+    "branch": "main",
+    "maintainer": "ktoso@apple.com",
+    "compatibility": [
+      {
+        "version": "5.2",
+        "commit": "0fd434556ce4c66bc803e867f6903587c69e55a2"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/SwiftyJSON/SwiftyJSON.git",
     "path": "SwiftyJSON",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

add swift cluster membership

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
  - 5.2+ AFAIR
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run


```
PASS: swift-cluster-membership, 5.2, 0fd434, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- swift-cluster-membership checked successfully against Swift 5.2 ---
```