### PR TITLE
add distributed tracing

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2967,7 +2967,7 @@
     "repository": "Git",
     "url": "https://github.com/apple/swift-distributed-tracing",
     "path": "swift-distributed-tracing",
-    "branch": "master",
+    "branch": "main",
     "maintainer": "ktoso@apple.com",
     "compatibility": [
       {

--- a/projects.json
+++ b/projects.json
@@ -2965,6 +2965,37 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-distributed-tracing",
+    "path": "swift-distributed-tracing",
+    "branch": "master",
+    "maintainer": "ktoso@apple.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "73f2b523f0f1b04b0c58979a10fafc7860819889"
+      },
+      {
+        "version": "5.2",
+        "commit": "73f2b523f0f1b04b0c58979a10fafc7860819889"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/SwiftyJSON/SwiftyJSON.git",
     "path": "SwiftyJSON",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

adds distributed tracing repo.

Important to run both 5.0 and 5.2 since the project has a bunch of features only available on 5.2

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
  - 5.0+
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run

```
PASS: swift-distributed-tracing, 5.2, 73f2b5, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- swift-distributed-tracing checked successfully against Swift 5.2 ---
```

