### PR TITLE
add async http client

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2994,6 +2994,33 @@
   },
   {
     "repository": "Git",
+    "url": "git@github.com:swift-server/async-http-client",
+    "path": "async-http-client",
+    "branch": "main",
+    "maintainer": "ktoso@apple.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "a72c5adce3986ff6b5092ae0464a8f2675087860"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/apple/swift-nio-http2",
     "path": "swift-nio-http2",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

add async http client

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
  - 5.0+
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run

```
PASS: async-http-client, 5.2, a72c5a, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- async-http-client checked successfully against Swift 5.2 ---
```