### PR TITLE
Fix bug in checkout script

### DIFF
--- a/checkout
+++ b/checkout
@@ -59,7 +59,7 @@ def main():
             continue
         total_repos += 1
         for compatible_swift in repo['compatibility']:
-            project.checkout(root_path, repo, compatible_swift['commit'])
+            project_future.checkout(root_path, repo, compatible_swift['commit'])
     common.debug_print('='*40)
     common.debug_print('Repository Summary:')
     common.debug_print('      Total: %s' % total_repos)


### PR DESCRIPTION
`project` has been renamed to `project_future` in 51e08a09ae2b69b219575490da5849793cfa8304. 

Currently the `checkout` script fails when run.