### PR TITLE
Add swift-collections and swift-collections-benchmark

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4293,5 +4293,59 @@
         "action": "TestSwiftPackage"
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/apple/swift-collections",
+    "path": "swift-collections",
+    "branch": "main",
+    "maintainer": "klorentey@apple.com",
+    "compatibility": [
+      {
+        "version": "5.3",
+        "commit": "2d719d75a2065f213e58a5164384a3d2fcf9b59a"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/apple/swift-collections-benchmark",
+    "path": "swift-collections-benchmark",
+    "branch": "main",
+    "maintainer": "klorentey@apple.com",
+    "compatibility": [
+      {
+        "version": "5.3",
+        "commit": "49297647d1c0855eb33ec18cd6ee1181727c159b"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

Add the recently announced [Swift Collections][swift-collections] and [Swift Collections Benchmark][swift-collections-benchmark] packages to the source compatibility suite.

[swift-collections]: https://github.com/apple/swift-collections
[swift-collections-benchmark]: https://github.com/apple/swift-collections-benchmark

Note: This requires #508 for the precommit check to pass.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [X] be an *Xcode* or *swift package manager* project
- [X] support building on either Linux or macOS
- [X] target Linux, macOS, or iOS/tvOS/watchOS device
- [X] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests (**we build against 5.3**)
- [X] have maintainers who will commit to resolve issues in a timely manner
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [X] add value not already included in the suite
- [X] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* **Apache License, version 2.0**
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [X] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

```shellsession
$ swiftc --version
Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
Target: x86_64-apple-darwin20.4.0
$ /project_precommit_check swift-collections --swiftc /usr/bin/swiftc --earliest-compatible-swift-version 5.3
** CHECK **
--- Validating swift-collections Swift version 5.3 compatibility ---
--- Project configured to be compatible with Swift 5.3 ---
--- Checking swift-collections platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Checking installed Swift version ---
$ /usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ /Users/klorentey/Swift/swift-source-compat-suite/runner.py --swift-branch swift-5.3-branch --swiftc /usr/bin/swiftc --projects /Users/klorentey/Swift/swift-source-compat-suite/projects.json --include-repos 'path == "swift-collections"' --include-versions 'version == "5.3"' --include-actions 'action.startswith("Build")'
PASS: swift-collections, 5.3, bd9240, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
$ ./project_precommit_check swift-collections-benchmark --swiftc /usr/bin/swiftc --earliest-compatible-swift-version 5.3
** CHECK **
--- Validating swift-collections-benchmark Swift version 5.3 compatibility ---
--- Project configured to be compatible with Swift 5.3 ---
--- Checking swift-collections-benchmark platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Checking installed Swift version ---
$ /usr/bin/swiftc --version
--- Version check succeeded ---
--- Executing build actions ---
$ /Users/klorentey/Swift/swift-source-compat-suite/runner.py --swift-branch swift-5.3-branch --swiftc /usr/bin/swiftc --projects /Users/klorentey/Swift/swift-source-compat-suite/projects.json --include-repos 'path == "swift-collections-benchmark"' --include-versions 'version == "5.3"' --include-actions 'action.startswith("Build")'
PASS: swift-collections-benchmark, 5.3, 492976, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- swift-collections-benchmark checked successfully against Swift 5.3 ---
```