### PR TITLE
[Stress Tester XFAils] Update XFails

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -114,14 +114,14 @@
     "issueUrl" : "https://bugs.swift.org/browse/SR-14497"
   },
   {
-    "path" : "*\/MovieSwift\/MovieSwift\/Packages\/Backend\/Sources\/Backend\/services\/APIService.swift",
+    "path" : "*\/MovieSwift\/MovieSwift\/Packages\/Backend\/Sources\/Backend\/services\/ImageService.swift",
     "issueDetail" : {
-      "kind" : "typeContextInfo",
-      "offset" : 1158
+      "kind" : "codeComplete",
+      "offset" : 1093
     },
     "applicableConfigs" : [
       "main"
     ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-14498"
+    "issueUrl" : "https://github.com/apple/swift/pull/36943"
   }
 ]


### PR DESCRIPTION
- https://bugs.swift.org/browse/SR-14498 has been fixed
- Found a new issue that already has a PR fixing it, up