### PR TITLE
Drop Kingfisher 4.0 configuration

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1220,7 +1220,7 @@
     "compatibility": [
       {
         "version": "5.1",
-        "commit": "23ef6c73ee3bc12ee3940136aea54bd44a02e93e"
+        "commit": "44450a8f564d7c0165f736ba2250649ff8d3e556"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -1219,10 +1219,6 @@
     "maintainer": "onev@onevcat.com",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "a5d1214220b8ddf29acf7c08c8bb42993ed56c54"
-      },
-      {
         "version": "5.1",
         "commit": "23ef6c73ee3bc12ee3940136aea54bd44a02e93e"
       }


### PR DESCRIPTION
### Pull Request Description

Drops Kingfisher configuration for 4.0, as the commit reference in projects.json no longer exists on the branch.