### PR TITLE
Fix Kingfisher build by the new scheme settings

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1219,12 +1219,8 @@
     "maintainer": "onev@onevcat.com",
     "compatibility": [
       {
-        "version": "4.0",
-        "commit": "a5d1214220b8ddf29acf7c08c8bb42993ed56c54"
-      },
-      {
         "version": "5.1",
-        "commit": "23ef6c73ee3bc12ee3940136aea54bd44a02e93e"
+        "commit": "44450a8f564d7c0165f736ba2250649ff8d3e556"
       }
     ],
     "platforms": [
@@ -1241,7 +1237,7 @@
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-macOS",
+        "scheme": "Kingfisher",
         "destination": "generic/platform=macOS",
         "configuration": "Release",
         "tags": "sourcekit-disabled"
@@ -1249,14 +1245,14 @@
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-tvOS",
+        "scheme": "Kingfisher",
         "destination": "generic/platform=tvOS",
         "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Kingfisher.xcworkspace",
-        "scheme": "Kingfisher-watchOS",
+        "scheme": "Kingfisher",
         "destination": "generic/platform=watchOS",
         "configuration": "Release"
       }


### PR DESCRIPTION
This is a fix for #527 

It now succeeds as below:

```
--- Executing build actions ---
$ /Users/onevcat/Desktop/swift-source-compat-suite/runner.py --swift-branch swift-5.1-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/onevcat/Desktop/swift-source-compat-suite/projects.json --include-repos 'path == "Kingfisher"' --include-versions 'version == "5.1"' --include-actions 'action.startswith("Build")'
$ git -C /Users/onevcat/Desktop/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 5.1, 44450a, Kingfisher, generic/platform=iOS
$ git -C /Users/onevcat/Desktop/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 5.1, 44450a, Kingfisher, generic/platform=macOS
$ git -C /Users/onevcat/Desktop/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 5.1, 44450a, Kingfisher, generic/platform=tvOS
$ git -C /Users/onevcat/Desktop/swift-source-compat-suite/project_cache/Kingfisher rev-parse --show-toplevel
PASS: Kingfisher, 5.1, 44450a, Kingfisher, generic/platform=watchOS
========================================
Action Summary:
     Passed: 4
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 4
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Kingfisher checked successfully against Swift 5.1 ---
```