### PR TITLE
Add Doggie

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -650,6 +650,33 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/SusanDoggie/Doggie.git",
+    "path": "Doggie",
+    "branch": "main",
+    "maintainer": "susan.doggie@gmail.com",
+    "compatibility": [
+      {
+        "version": "5.3",
+        "commit": "a2d58a0775670b71b756c071ac744b304d05a99f"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/ankurp/Dollar.git",
     "path": "Dollar",
     "branch": "master",

--- a/projects.json
+++ b/projects.json
@@ -673,6 +673,13 @@
       {
         "action": "TestSwiftPackage"
       }
+    ],
+    "xfail": [
+        {
+            "issue": "https://bugs.swift.org/browse/SR-14580",
+            "compatibility": "5.3",
+            "branch": ["main", "release/5.5"]
+        }
     ]
   },
   {

--- a/projects.json
+++ b/projects.json
@@ -668,24 +668,24 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "swiftpm"
+        "tags": "swiftpm",
+        "xfail": [
+            {
+                "issue": "https://bugs.swift.org/browse/SR-12736",
+                "platform": "Linux",
+                "compatibility": "5.3",
+                "branch": ["main", "release/5.5", "release/5.4"]
+            },
+            {
+                "issue": "https://bugs.swift.org/browse/SR-14580",
+                "compatibility": "5.3",
+                "branch": ["main", "release/5.5"]
+            }
+        ]
       },
       {
         "action": "TestSwiftPackage"
       }
-    ],
-    "xfail": [
-        {
-            "issue": "https://bugs.swift.org/browse/SR-12736",
-            "platform": "Linux",
-            "compatibility": "5.3",
-            "branch": ["main", "release/5.5", "release/5.4"]
-        },
-        {
-            "issue": "https://bugs.swift.org/browse/SR-14580",
-            "compatibility": "5.3",
-            "branch": ["main", "release/5.5"]
-        }
     ]
   },
   {

--- a/projects.json
+++ b/projects.json
@@ -676,6 +676,12 @@
     ],
     "xfail": [
         {
+            "issue": "https://bugs.swift.org/browse/SR-12736",
+            "platform": "Linux",
+            "compatibility": "5.3",
+            "branch": ["main", "release/5.5", "release/5.4"]
+        },
+        {
             "issue": "https://bugs.swift.org/browse/SR-14580",
             "compatibility": "5.3",
             "branch": ["main", "release/5.5"]


### PR DESCRIPTION
### Pull Request Description

Add project [Doggie](https://github.com/SusanDoggie/Doggie)

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests (we build against 5.3)
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* **MIT**
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

```
./project_precommit_check Doggie  --earliest-compatible-swift-version 5.3
** CHECK **
--- Validating Doggie Swift version 5.3 compatibility ---
--- Project configured to be compatible with Swift 5.3 ---
--- Checking Doggie platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check failed ---
Expected version:
Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
Target: x86_64-apple-darwin20.3.0

Current version:
Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
Target: arm64-apple-darwin20.4.0

warning: Unexpected swiftc version. Expected swiftc for Swift 5.3 can be found in Xcode 12.4 (contains Swift 5.3.2).
warning: Continuing to build with unexpected swiftc version.

--- Executing build actions ---
$ /Users/Susan/dev/swift-source-compat-suite/runner.py --swift-branch swift-5.3-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/Susan/dev/swift-source-compat-suite/projects.json --include-repos 'path == "Doggie"' --include-versions 'version == "5.3"' --include-actions 'action.startswith("Build")'
PASS: Doggie, 5.3, a2d58a, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Doggie checked successfully against Swift 5.3 ---
```