### PR TITLE
[DO NOT MERGE] Remove ACHNBrowserUI from stress tester suite

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -20,8 +20,7 @@
         "project": "ACHNBrowserUI/ACHNBrowserUI.xcodeproj",
         "target": "ACHNBrowserUI",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke"
+        "configuration": "Release"
       }
     ]
   },


### PR DESCRIPTION
ACHNBrowserUI takes too long to stress test and we are running into a Jenkins timeout when we’re not stopping the test run early because of a failure. Let’s see if the test suite runs through again if we remove it.