### PR TITLE
Add BricBrac

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -310,6 +310,33 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/glimpseio/BricBrac",
+    "path": "BricBrac",
+    "branch": "main",
+    "maintainer": "marc@glimpse.io",
+    "compatibility": [
+      {
+        "version": "5.3",
+        "commit": "92447f2c02b62c373f60d8e76e684a645fcd570a"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/carekit-apple/CareKit.git",
     "path": "CareKit",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Add [BricBrac](http://github.com/glimpseio/BricBrac)

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests (we build against 5.3)
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* **MIT**
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

```
marc@bix swift-source-compat-suite % ./project_precommit_check BricBrac --earliest-compatible-swift-version 5.3
** CHECK **
--- Validating BricBrac Swift version 5.3 compatibility ---
--- Project configured to be compatible with Swift 5.3 ---
--- Checking BricBrac platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check failed ---
Expected version:
Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
Target: x86_64-apple-darwin20.3.0

Current version:
Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
Target: x86_64-apple-darwin20.4.0

warning: Unexpected swiftc version. Expected swiftc for Swift 5.3 can be found in Xcode 12.4 (contains Swift 5.3.2).
warning: Continuing to build with unexpected swiftc version.

--- Executing build actions ---
$ /opt/src/github/swift-source-compat-suite/runner.py --swift-branch swift-5.3-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /opt/src/github/swift-source-compat-suite/projects.json --include-repos 'path == "BricBrac"' --include-versions 'version == "5.3"' --include-actions 'action.startswith("Build")'
PASS: BricBrac, 5.3, 92447f, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- BricBrac checked successfully against Swift 5.3 ---
```