### PR TITLE
Add mqtt-nio

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4396,5 +4396,29 @@
         "action": "TestSwiftPackage"
       }
     ]
-  }
+  },
+  {
+     "repository": "Git",
+     "url": "https://github.com/sroebert/mqtt-nio",
+     "path": "mqtt-nio",
+     "branch": "main",
+     "maintainer": "steven@roebert.nl",
+     "compatibility": [
+       {
+         "version": "5.1",
+         "commit": "17794a4ac977b7a30fe6aac669c3a1b3ce55cc21"
+       }
+     ],
+     "platforms": [
+       "Darwin",
+       "Linux"
+     ],
+     "actions": [
+       {
+         "action": "BuildSwiftPackage",
+         "configuration": "release",
+         "tags": "swiftpm"
+       }
+     ]
+   }
 ]


### PR DESCRIPTION
### Pull Request Description

Add the mqtt-nio package to the source compatibility suite.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests (we build against 5.1 and 5.4)
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* **MIT**
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

```console
$ ./project_precommit_check --earliest-compatible-swift-version 5.1 mqtt-nio
** CHECK **
--- Validating mqtt-nio Swift version 5.1 compatibility ---
--- Project configured to be compatible with Swift 5.1 ---
--- Checking mqtt-nio platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
--- Version check failed ---
Expected version:
Apple Swift version 5.1 (swiftlang-1100.0.270.6 clang-1100.0.32.1)
Target: x86_64-apple-darwin18.2.0

Current version:
Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
Target: x86_64-apple-darwin20.2.0

warning: Unexpected swiftc version. Expected swiftc for Swift 5.1 can be found in Xcode 11 Beta 6 (contains Swift 5.1).
warning: Continuing to build with unexpected swiftc version.

--- Executing build actions ---
$ /Users/steven/Documents/development/personal/swift-source-compat-suite/runner.py --swift-branch swift-5.1-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/steven/Documents/development/personal/swift-source-compat-suite/projects.json --include-repos 'path == "mqtt-nio"' --include-versions 'version == "5.1"' --include-actions 'action.startswith("Build")'
PASS: mqtt-nio, 5.1, 17794a, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- mqtt-nio checked successfully against Swift 5.1 ---
```