### PR TITLE
Add '--report-time-path=abs.path' option to record xcode projects bui…

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -44,6 +44,10 @@ def main():
 
     swift_flags = args.add_swift_flags
 
+    time_reporter = None
+    if args.report_time_path:
+        time_reporter = project_future.TimeReporter(args.report_time_path)
+
     index = json.loads(open(args.projects).read())
     result = project_future.ProjectListBuilder(
         args.include_repos,
@@ -69,7 +73,8 @@ def main():
                     args.build_config,
                     args.strip_resource_phases,
                     args.only_latest_versions,
-                    args.project_cache_path
+                    args.project_cache_path,
+                    time_reporter
                 ),
             ),
         ),


### PR DESCRIPTION


### Pull Request Description

This PR adds a new argument, `--report-time-path=abs.path` to provide an option to record build time of projects. This is currently works for xcode projects only. Passing this argument, `runner.py` creates a TimeReporter object which is passed along to the project builder, in order to keep track of xcode projects' build time and write it to the specified json file upon the exit of the script.

### Acceptance Criteria

This does not add a new test project in the suite.