### PR TITLE
XFAIL swift-distributed-tracing on release/5.5.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3538,7 +3538,7 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15060",
             "compatibility": ["5.0", "5.2"],
-            "branch": ["main"]
+            "branch": ["main", "release/5.5"]
           }
         ]
       },


### PR DESCRIPTION
This project is also failing on the `release/5.5` branch: https://ci.swift.org/job/swift-5.5-source-compat-suite/104/console