### PR TITLE
Manage the project XFails under a different job type for the stress tester

### DIFF
--- a/build_incremental.py
+++ b/build_incremental.py
@@ -44,6 +44,7 @@ def main():
                 args.swiftc,
                 args.swift_version,
                 args.swift_branch,
+                args.job_type,
                 args.sandbox_profile_xcodebuild,
                 args.sandbox_profile_package,
                 args.add_swift_flags,

--- a/projects.json
+++ b/projects.json
@@ -26,7 +26,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15116",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       }
@@ -680,12 +681,14 @@
             {
                 "issue": "https://bugs.swift.org/browse/SR-12736",
                 "compatibility": "5.3",
-                "branch": ["main", "release/5.5", "release/5.4"]
+                "branch": ["main", "release/5.5", "release/5.4"],
+                "job": ["source-compat"]
             },
             {
                 "issue": "https://bugs.swift.org/browse/SR-14659",
                 "compatibility": "5.3",
-                "branch": ["main", "release/5.5", "release/5.4"]
+                "branch": ["main", "release/5.5", "release/5.4"],
+                "job": ["source-compat"]
             }
         ]
       },
@@ -816,7 +819,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15106",
             "compatibility": ["4.0"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       }
@@ -1236,7 +1240,8 @@
           {
             "issue": "rdar://problem/75437284",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -1250,12 +1255,14 @@
           {
             "issue": "rdar://problem/75437284",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           },
           {
             "issue": "https://bugs.swift.org/browse/SR-15107",
             "compatibility": ["4.0"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       }
@@ -1287,7 +1294,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15109",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -1641,7 +1649,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15116",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       }
@@ -2184,7 +2193,8 @@
             "issue": "rdar://problem/68590422",
             "compatibility": ["4.0", "5.1"],
             "branch": ["release/5.4"],
-            "configuration": "debug"
+            "configuration": "debug",
+            "job": ["source-compat"]
           }
         ]
       },
@@ -2199,7 +2209,8 @@
             "issue": "rdar://problem/68590422",
             "compatibility": ["4.0", "5.1"],
             "branch": ["release/5.4"],
-            "configuration": "debug"
+            "configuration": "debug",
+            "job": ["source-compat"]
           }
         ]
       },
@@ -2246,7 +2257,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15109",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -2420,7 +2432,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15232",
             "compatibility": ["4.2", "5.3"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ],
         "configuration": "release"
@@ -2485,7 +2498,8 @@
         "xfail": {
           "issue": "https://bugs.swift.org/browse/SR-11141",
           "compatibility": "5.1",
-          "branch": ["main", "release/5.3", "release/5.4", "release/5.5"]
+          "branch": ["main", "release/5.3", "release/5.4", "release/5.5"],
+          "job": ["source-compat"]
         }
       },
       {
@@ -2549,7 +2563,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-14655;rdar://81276100",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -2563,7 +2578,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-14655;rdar://81276100",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -2577,7 +2593,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-14655;rdar://81276100",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       }
@@ -2611,7 +2628,8 @@
             {
                 "issue": "https://bugs.swift.org/browse/SR-13190",
                 "compatibility": ["4.0", "5.1"],
-                "branch": ["main", "release/5.4", "release/5.5"]
+                "branch": ["main", "release/5.4", "release/5.5"],
+                "job": ["source-compat"]
             }
         ]
       },
@@ -3128,7 +3146,8 @@
           {
             "issue": "rdar://81180448",
             "compatibility": ["4.2", "5.0", "5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -3953,7 +3972,8 @@
           {
             "issue": "https://bugs.swift.org/browse/SR-15105",
             "compatibility": ["5.1"],
-            "branch": ["main", "release/5.5"]
+            "branch": ["main", "release/5.5"],
+            "job": ["source-compat"]
           }
         ]
       },
@@ -4297,7 +4317,8 @@
             "issue": "https://bugs.swift.org/browse/SR-15105",
             "compatibility": ["5.1"],
             "branch": ["main", "release/5.5"],
-            "configuration": "debug"
+            "configuration": "debug",
+            "job": ["source-compat"]
           }
         ]
       },

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -258,6 +258,7 @@ class StressTesterRunner(object):
           '--verbose',
           '--swiftc', self.wrapper,
           '--swift-branch', self.swift_branch,
+          '--job-type', 'stress-tester',
           '--default-timeout', str(-1),
           '--only-latest-versions',
           # archs override is set to arm64 for generic/iOS actions that would otherwise invoke the stress tester for both arm64 and armv7
@@ -284,7 +285,7 @@ class StressTesterRunner(object):
 
     def _process_output(self, results_path, xfails_path):
         if not os.path.isfile(results_path):
-            return True
+            return not self.compat_runner_failed
 
         with open(results_path, 'rb') as results_file:
             results = json.load(results_file, encoding='utf-8')
@@ -305,7 +306,7 @@ class StressTesterRunner(object):
         num_xfail_issues = len(results['expectedIssues'])
         unmatched = results['unmatchedExpectedIssues']
 
-        success = num_failures == 0 and len(unmatched) == 0
+        success = self.compat_runner_failed == False and num_failures == 0 and len(unmatched) == 0
 
         if num_xfails > 0:
             print('Expected stress tester issues:')
@@ -336,9 +337,7 @@ class StressTesterRunner(object):
         print('SourceKit Stress Tester summary:')
 
         print('  {} underlying source compatibility build'.format('failed' if self.compat_runner_failed else 'passed'))
-        if self.compat_runner_failed:
-            print('      > treat this as a source compatibility failure')
-
+        
         print('  {} XFails not processed'.format(len(xfails_not_processed)))
         if num_failures > 0:
             print('      > see "XFails not processed" how to handle them. This is an info, not an error')

--- a/runner.py
+++ b/runner.py
@@ -65,6 +65,7 @@ def main():
                     args.swiftc,
                     args.swift_version,
                     args.swift_branch,
+                    args.job_type,
                     args.sandbox_profile_xcodebuild,
                     args.sandbox_profile_package,
                     swift_flags,


### PR DESCRIPTION
Currently we’re in a state again in which some project succeed to build in the stress tester CI job but fail to build in the source compatibility suite CI job (rdar://82333521). We are thus mistakingly receiving UPASSes in the stress tester CI job.

To work around this, introduce the notion of job types to the source compatibility runner and its associated XFails. By default everything runs as the "source-compat" job, only the stress tester overrides the job to "stress-tester". That way we can selectively XFail jobs only for the stress tester in `projects.json`.

Since the stress tester now controls its own project build XFails, a project build failure will also cause a stress tester failure.

rdar://62080167