### PR TITLE
Remove XFAIL for swift-nio-ssl

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3308,12 +3308,6 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "xfail": [
-          {
-            "issue": "rdar://83452858",
-            "compatibility": ["5.0"]
-          }
-        ],
         "tags": "sourcekit-disabled swiftpm"
       },
       {


### PR DESCRIPTION
Fixed by a change to swiftpm.

rdar://83452858