### PR TITLE
XFAIL swift-nio-ssl only on release/5.5

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3308,6 +3308,13 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "xfail": [
+          {
+            "issue": "rdar://83452858",
+            "compatibility": ["5.0"],
+            "branch": ["release/5.5"]
+          }
+        ],
         "tags": "sourcekit-disabled swiftpm"
       },
       {


### PR DESCRIPTION
We're still seeing the failure on 5.5. XFAIL for now.
