### PR TITLE
Split-off versions of SwiftLint that no longer compile on Linux

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2977,7 +2977,7 @@
   {
     "repository": "Git",
     "url": "https://github.com/realm/SwiftLint.git",
-    "path": "SwiftLint",
+    "path": "SwiftLint-Legacy",
     "branch": "master",
     "compatibility": [
       {
@@ -2995,6 +2995,36 @@
       {
         "version": "5.1",
         "commit": "ac8abbb3a72874eb1dedd6305ab9560e9d096eb4"
+      }
+    ],
+    "maintainer": "jp@jpsim.com",
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/realm/SwiftLint.git",
+    "path": "SwiftLint",
+    "branch": "master",
+    "compatibility": [
+      {
+        "version": "5.2",
+        "commit": "180d94132758dd183124ab1e63d6aa8e10023ec2"
+      },
+      {
+        "version": "5.3",
+        "commit": "e820e750b08bd67bc9d98f4817868e9bc3d5d865"
       }
     ],
     "maintainer": "jp@jpsim.com",


### PR DESCRIPTION
One of SwiftLint's dependencies is SWXMLHash. In versions of
that package prior to its 5.0.0 release, the XMLParser type
was imported from Foundation. But, that type has since moved
on Linux platforms to the FoundationXML module. This leads to
build failures such as:

```
swift-source-compat-suite/project_cache/SwiftLint/.build/
checkouts/SWXMLHash/Source/SWXMLHash.swift:296:38: error:
'XMLParser' is unavailable: This type has moved to the
FoundationXML module. Import that module to use it.
    func parser(_ parser: Foundation.XMLParser,
                                     ^~~~~~~~~
```

SwiftLint updated its dependency on SWXMLHash to be >= 5.0.0
in [f5174b316878793e4c24b63741459c1b852f480b](https://github.com/realm/SwiftLint/blob/f5174b316878793e4c24b63741459c1b852f480b/Package.resolved), which happened
on Oct 8th, 2019, a little after Swift 5.1 compatability
was implemented.

Thus, this patch marks all versions of SwiftLint that are tagged
for 5.1 compatability as only compatible with Darwin, under the
new name "SwiftLint-Legacy", so that we still test those versions
of SwiftLint.

Next, I have created a new SwiftLint path that includes both
Darwin and Linux, and forwarded their compatability tests to test
SwiftLint's Swift 5.2 and Swift 5.3 releases.

Resolves rdar://83374141