### PR TITLE
XFAIL swift-nio-ssl on release/5.5 branch

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3357,6 +3357,13 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "xfail": [
+          {
+            "issue": "rdar://83865752",
+            "compatibility": ["5.0"],
+            "branch": ["release/5.5"]
+          }
+        ],
         "tags": "sourcekit-disabled swiftpm"
       },
       {


### PR DESCRIPTION
Seeing failures on SwiftCI even after the update to new version

