### PR TITLE
Update the old nio-ssl version to work around the compiler

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3342,7 +3342,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "16de4b45c7cbe9815f995dd1539e6b7c4f0980a5"
+        "commit": "6363cdf6d2fb863e82434f3c4618f4e896e37569"
       },
       {
         "version": "5.3",


### PR DESCRIPTION
This updates the swift-nio-ssl 5.0 version to the last release that supported that far back in order to fix rdar://83865752.