### PR TITLE
Add a Swift 5.0 version of Result

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2274,6 +2274,10 @@
       {
         "version": "4.2",
         "commit": "2fe5b325a8a54e77c545b2f511213420da133b8c"
+      },
+      {
+        "version": "5.0",
+        "commit": "c30700bfcab7f555bf1d386fdd609407a94f369c"
       }
     ],
     "maintainer": "matt@diephouse.com",


### PR DESCRIPTION
Before #613 the SourceKit stress tester was using the 5.1 version of Result and had XFails that matched the source offset of that version of the library. Use the commit hash that was previously used for 5.1 for Swift 5.0.