### PR TITLE
Add swift-protobuf-plugin-example to test SwiftPM build tool plugin functionality

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3350,6 +3350,39 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/abertelrud/swift-protobuf-plugin-example.git",
+    "path": "swift-protobuf-plugin-example",
+    "branch": "main",
+    "maintainer": "anders@apple.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "85bec04626e571ae8391175285e0cf111140fddc"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "SwiftPM plugins are only supported in SwiftPM 5.6 and later",
+            "compatibility": ["5.0"],
+            "branch": ["release/5.5"]
+          }
+        ]
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/apple/swift-system",
     "path": "swift-system",
     "branch": "main",


### PR DESCRIPTION
Add https://github.com/abertelrud/swift-protobuf-plugin-example.git to the source compatibility suite.

This is a test of SwiftPM functionality that is new in SwiftPM 5.6.  Since the compatibility versions use Swift language versions and not Swift toolchain versions, it was suggested to use an XFAIL for the `release/5.5` branch.

This is a sample package that uses a modified version of swift-protobuf to which a SwiftPM build tool plugin has been added.  The sample verifies that `.proto` files get processed properly.

This is currently only Darwin but a future PR will extend it to Linux.

rdar://84315022