### PR TITLE
add entry for the standard library preview repository

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2780,6 +2780,32 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-standard-library-preview.git",
+    "path": "swift-standard-library-preview",
+    "branch": "main",
+    "maintainer": "guillaume.lessard@apple.com",
+    "compatibility": [
+      {
+        "version": "5.1",
+        "commit": "6f72db4c56431d2a2aba0ea41697f60f7cd5917e"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/malcommac/SwiftDate",
     "path": "SwiftDate",
     "branch": "master",

--- a/projects.json
+++ b/projects.json
@@ -2786,7 +2786,7 @@
     "maintainer": "guillaume.lessard@apple.com",
     "compatibility": [
       {
-        "version": "5.1",
+        "version": "5.0",
         "commit": "6f72db4c56431d2a2aba0ea41697f60f7cd5917e"
       }
     ],


### PR DESCRIPTION
### Pull Request Description

Add an entry for the standard library preview repository.
On Linux, the project requires the --enable-test-discovery flag to be passed in order to build on Swift 5.1 through 5.3.
I don't know where to add this.

This project supports Swift 5.1 and up; there is no Swift 4.0 branch.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
