### PR TITLE
Use different metavar for `--filter-by-project` instead of `--filter-by-tag` in run_sk_stress_test

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -67,7 +67,7 @@ def parse_args():
                         help='Only run project actions with the given tag',
                         default='sourcekit')
     parser.add_argument('--filter-by-project',
-                        metavar='TAG',
+                        metavar='PROJECT',
                         help='Only stress test the given project')
     parser.add_argument('--sourcekit-xfails',
                         metavar='PATH',


### PR DESCRIPTION
I just realized `--filter-by-project` is using the same metavar as `--filter-by-tag`. Most likely a copy-paste error.
