### PR TITLE
[XFail] Xfailed projects failing on linux.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -202,7 +202,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "swiftpm"
+        "tags": "swiftpm",
+        "xfail": [
+            {
+                "issue": "rdar://83373076",
+                "platform": "Linux",
+                "compatibility": "5.0",
+                "branch": ["main", "release/5.6"],
+                "job": ["source-compat"]
+            }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -1307,7 +1316,24 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+            {
+                "issue": "rdar://83373628",
+                "platform": "Linux",
+                "compatibility": "5.0",
+                "branch": ["main", "release/5.6"],
+                "job": ["source-compat"]
+            },
+            {
+                "issue": "rdar://83373628",
+                "platform": "Linux",
+                "compatibility": "4.0",
+                "branch": ["main", "release/5.6"],
+                "job": ["source-compat"]
+            }
+
+        ]
       }
     ]
   },
@@ -1753,7 +1779,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+            {
+                "issue": "rdar://83373864",
+                "platform": "Linux",
+                "compatibility": "4.2",
+                "branch": ["main", "release/5.6"],
+                "job": ["source-compat"]
+            }
+        ]
       }
     ]
   },
@@ -2959,7 +2994,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+            {
+                "issue": "rdar://83374141",
+                "platform": "Linux",
+                "compatibility": "5.0",
+                "branch": ["main", "release/5.6"],
+                "job": ["source-compat"]
+            }
+        ]
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
The following tests are failing on Ubuntu with tools built from
release/5.6 and main.

https://ci.swift.org/job/swift-5.6-source-compat-suite-ubuntu-2004/1/
https://ci.swift.org/view/Source%20Compatibility/job/swift-source-compat-suite-ubuntu-2004/111/

```
========================================
Failures:
  FAIL: AsyncNinja, 5.0, 7bd7ea, Swift Package
  FAIL: Kitura, 5.0, 8578c4, Swift Package
  FAIL: Kitura, 4.0, f1c316, Swift Package
  FAIL: Perfect, 4.2, cdc17d, Swift Package
  FAIL: SwiftLint, 5.0, 180d94, Swift Package
========================================
```