### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -235,17 +235,6 @@
     "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/moviesList\/base\/MoviesList.swift",
     "issueDetail" : {
       "kind" : "codeComplete",
-      "offset" : 5596
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://bugs.swift.org/browse/SR-14694"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/moviesList\/base\/MoviesList.swift",
-    "issueDetail" : {
-      "kind" : "codeComplete",
       "offset" : 5685
     },
     "applicableConfigs" : [


### PR DESCRIPTION
Remove another timeout that no longer occurs on the new CI machines
