### PR TITLE
Update string processing to swift/main

### DIFF
--- a/common.py
+++ b/common.py
@@ -50,7 +50,7 @@ branches = {
         'swift-collections': '1.0.1',
         'swift-numerics': '1.0.1',
         'swift-system': '1.1.1',
-        'swift-experimental-string-processing': 'dev/8',
+        'swift-experimental-string-processing': 'swift/main',
     },
     'release/5.6': {
         'llvm-project': 'swift/release/5.6',


### PR DESCRIPTION
Switch to using swift/main as the integration branch for apple/swift-experimental-string-processing.

Integration process documentation: apple/swift-experimental-string-processing#170
Friend PRs: apple/swift#41588, apple/swift-experimental-string-processing#192