### PR TITLE
Do not clean the Xcode build folder if the action specifies 'clean_bu…

### DIFF
--- a/project_future.py
+++ b/project_future.py
@@ -1056,7 +1056,12 @@ class ActionBuilder(Factory):
         self.current_platform = platform.system()
         self.added_swift_flags = added_swift_flags
         self.added_xcodebuild_flags = added_xcodebuild_flags
-        self.skip_clean = skip_clean
+        # Make sure Xcode build folder is not cleaned by 'git' when
+        # 'clean_build' is explicitly set 'false'.
+        clean_build = True
+        if 'clean_build' in action:
+            clean_build = action['clean_build']
+        self.skip_clean = skip_clean or not clean_build
         self.build_config = build_config
         self.strip_resource_phases = strip_resource_phases
         self.time_reporter = time_reporter


### PR DESCRIPTION
…ild' to be 'false'

Without this fix, GIT command cleaned the build folder even if the
action specified 'clean_build' to be 'false'. This fix allows an
individual action to skip clean when 'clean_build' is explicitly
set 'false'.

### Pull Request Description

Replace with a description of this pull request. Instructions for adding
projects are available in the README.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [ ] be an *Xcode* or *swift package manager* project
- [ ] support building on either Linux or macOS
- [ ] target Linux, macOS, or iOS/tvOS/watchOS device
- [ ] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [ ] have maintainers who will commit to resolve issues in a timely manner
- [ ] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [ ] add value not already included in the suite
- [ ] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [ ] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
