### PR TITLE
Mark swift-protobuf-plugin-example as XFAIL until rdar://90955872 is fixed

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3434,6 +3434,12 @@
             "issue": "SwiftPM plugins are only supported in SwiftPM 5.6 and later",
             "compatibility": ["5.0"],
             "branch": ["release/5.5"]
+          },
+          {
+            "issue": "rdar://90955872",
+            "compatibility": ["5.0"],
+            "branch": ["main", "release/5.5", "release/5.6"],
+            "job": ["source-compat"]
           }
         ]
       },


### PR DESCRIPTION
### Pull Request Description

This marks the swift-protobuf-plugin-example test as XFAIL.  There seems to be a bug in which SwiftPM is no longer respecting `--disable-sandbox` for plugins, and this nesting of sandboxes causes the invocation of the package plugin to fail.
