### PR TITLE
Revert "Mark swift-protobuf-plugin-example as XFAIL until rdar://90955872 is fixed"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3434,12 +3434,6 @@
             "issue": "SwiftPM plugins are only supported in SwiftPM 5.6 and later",
             "compatibility": ["5.0"],
             "branch": ["release/5.5"]
-          },
-          {
-            "issue": "rdar://90955872",
-            "compatibility": ["5.0"],
-            "branch": ["main", "release/5.5", "release/5.6"],
-            "job": ["source-compat"]
           }
         ]
       },


### PR DESCRIPTION
SwiftPM has now been fixed.

This reverts commit 0c90004734822014a6bc44b8694b36d904b73eae.