### PR TITLE
Un-XFAIL SRP on main now that SR-13190 is fixed

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2567,7 +2567,13 @@
             {
                 "issue": "https://bugs.swift.org/browse/SR-13190",
                 "compatibility": ["4.0", "5.0"],
-                "branch": ["main", "release/5.4", "release/5.5", "release/5.6"],
+                "branch": ["release/5.4", "release/5.5", "release/5.6"],
+                "job": ["source-compat"]
+            },
+            {
+                "issue": "rdar://91670339",
+                "compatibility": ["4.0"],
+                "branch": ["main"],
                 "job": ["source-compat"]
             }
         ]


### PR DESCRIPTION
Now that https://bugs.swift.org/browse/SR-13190 is fixed we get UPASS for the SRP package, so we should remove the XFAIL for main.