### PR TITLE
un-xfail SRP project on main

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2567,7 +2567,7 @@
             {
                 "issue": "https://bugs.swift.org/browse/SR-13190",
                 "compatibility": ["4.0", "5.0"],
-                "branch": ["main", "release/5.4", "release/5.5", "release/5.6"],
+                "branch": ["release/5.4", "release/5.5", "release/5.6"],
                 "job": ["source-compat"]
             }
         ]


### PR DESCRIPTION
It's passing now: https://ci.swift.org/job/swift-main-source-compat-suite-debug//32/console