### PR TITLE
Added Violet - Python VM written in Swift

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4329,5 +4329,31 @@
          "tags": "swiftpm"
        }
      ]
+   },
+   {
+     "repository": "Git",
+     "url": "https://github.com/LiarPrincess/Violet",
+     "path": "violet",
+     "branch": "main",
+     "maintainer": "mail@liarprincess.me",
+     "compatibility": [
+       {
+         "version": "5.3",
+         "commit": "8217bfb0761c1630c94b88cc1fbe842bba40eb3d"
+       }
+     ],
+     "platforms": [
+       "Darwin",
+       "Linux"
+     ],
+     "actions": [
+       {
+         "action": "BuildSwiftPackage",
+         "configuration": "release"
+       },
+       {
+         "action": "TestSwiftPackage"
+       }
+     ]
    }
 ]


### PR DESCRIPTION
### Pull Request Description

Adding [Violet - Python VM written in Swift](https://github.com/LiarPrincess/Violet).

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] **Be an *Xcode* or *swift package manager* project**

    Swift Package Manager

- [x] **Target Linux, macOS, or iOS/tvOS/watchOS device**

    Tested on:

    - macOS
      - Intel
        - 11.6.2 (BigSur) + Xcode 12.4 (Swift 5.3.2)
        - 11.6.2 (BigSur) + Xcode 13.0 (Swift 5.5)
      - Apple
        - ⚠️ Not tested! I don't have M1. ⚠️
    - Ubuntu
      - 21.04 + Swift 5.4.2 - use `make test` and `make pytest`
    - Docker
      - `swift:latest` (5.6.0) - use `make docker-test` and `make docker-pytest`
      - `swift:5.3.2` - use `make docker-test-old` and `make docker-pytest-old`

- [x] **Support building on either Linux or macOS**
- [x] **Maintain a project branch that builds against Swift 4.0 and passes any unit tests**

    No Swift 4.0 support, although from what I see there are some other projects (like [apple/swift-argument-parser](https://github.com/apple/swift-argument-parser)) that only support 5+.

    Our target in `project_precommit_check`:

    ```py
    '5.3': {
        'version': 'Apple Swift version 5.3.2 '
                    '(swiftlang-1200.0.45 clang-1200.0.32.28)\n'
                    'Target: x86_64-apple-darwin20.3.0\n',
        'description': 'Xcode 12.4 (contains Swift 5.3.2)',
        'branch': 'swift-5.3-branch'
    }
    ```

    We could go as low as [swift-argument-parser](https://github.com/apple/swift-argument-parser) allows us (from my tests it is 5.3 - I had “SPM was unable to reserve dependency” / build failures on earlier versions). If we removed this dependency then I think that we could go to 5.0 (with [some](https://github.com/apple/swift-evolution/blob/main/proposals/0255-omit-return.md) [changes](https://github.com/apple/swift-evolution/blob/main/proposals/0068-universal-self.md) in our code).

- [x] **Be contained in a publicly accessible git repository**

    [github.com/LiarPrincess/Violet](https://github.com/LiarPrincess/Violet)

- [x] **Have maintainers who will commit to resolve issues in a timely manner**

    [github.com/LiarPrincess](github.com/LiarPrincess). No guarantee of 10+ years of support.

- [x] **Be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm***

    Not tested on beta. All of the tested configurations were mentioned previously.

- [x] **Add value not already included in the suite**

    We have things like:
    - `Unsafe[Raw/Mutable]Pointers` + a lof of pointer arithmetic - most of the Swift projects try to stay away from any `Unsafe` things, we use them a lot. In Violet a single Python object is represented as an `UnsafeRawPointer` with manually calculated offsets for fields.
    - `ManagedBufferPointer` + tagged pointers - this one is not popular among Swift programmers (`Array` is more common). Our custom `BigInt` implementation is an union (via [tagged pointer](https://en.wikipedia.org/wiki/Tagged_pointer)) of `Int32` (called `Smi`, after [V8](https://github.com/v8/v8)) and a heap allocation (magnitude + sign representation) with ARC for garbage collection.
    - Tons of `UnicodeScalar` and `String.UnicodeScalarView` (+ `SubSequence`) - most Swift programmers use default `String` view (the one with on grapheme clusters).
    - A lot of unit tests that will excise all of the above mentioned features.
    - Quite sizable code base for an open source project (Violet is tiny if we measure it in enterprise scale). This may be helpful then working on Swift incremental compilation - change something in `VioletCore` and check which modules have been recompiled (I think that @CodaFi worked in this area last year).

- [x] **be licensed with one of the following permissive licenses:**
	* MIT
- [x] **pass `./project_precommit_check` script run**

  <details>
    <summary>stdout - macOS 11.6.2 (BigSur) on Intel + Xcode 12.4 (Swift 5.3.2)</summary>

    ```
    michal at michal-macbook in ~/GitHub/Swift-source/swift-source-compat-suite git:(Violet*)
    $ ./project_precommit_check violet --earliest-compatible-swift-version=5.3
    ** CHECK **
    --- Validating violet Swift version 5.3 compatibility ---
    --- Project configured to be compatible with Swift 5.3 ---
    --- Checking violet platform compatibility with Darwin ---
    --- Platform compatibility check succeeded ---
    --- Locating swiftc executable ---
    $ xcrun -f swiftc
    --- Checking installed Swift version ---
    $ '/Volumes/So it was important to treat it carefully/XCode12/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc' --version
    --- Version check succeeded ---
    --- Executing build actions ---
    $ /Users/michal/GitHub/Swift-source/swift-source-compat-suite/runner.py --swift-branch swift-5.3-branch --swiftc '/Volumes/So it was important to treat it carefully/XCode12/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc' --projects /Users/michal/GitHub/Swift-source/swift-source-compat-suite/projects.json --include-repos 'path == "violet"' --include-versions 'version == "5.3"' --include-actions 'action.startswith("Build")'
    PASS: violet, 5.3, 8217bf, Swift Package
    ========================================
    Action Summary:
        Passed: 1
        Failed: 0
        XFailed: 0
        UPassed: 0
          Total: 1
    ========================================
    Repository Summary:
          Total: 1
    ========================================
    Result: PASS
    ========================================
    --- violet checked successfully against Swift 5.3 ---
    ```
  </details>

### Other

**Release vs debug**

There are some differences between a `release` and `debug` configuration in Violet. In PR I submitted:
```json
"actions": [
  {
    "action": "BuildSwiftPackage",
    "configuration": "release"
  },
  {
    "action": "TestSwiftPackage"
  }
]
```

My intention is:
- build in release - from what I see it would execute: `command = [swift, 'build', '--package-path', path, '--verbose', '--configuration', configuration]` which is “ok”
- build + unit test in debug - from what I see it would execute: `command = [swift, 'test', '-C', path, '--verbose']` which is “ok”

Is my `project.json` configuration correct for this?

**Python tests**

We have an additional test suite written in Python where our VM is executing those files. You can run it with `make pytest` (or `make pytest-r` for release mode). It returns:
- `EXIT_SUCCESS` - all tests passed
- `EXIT_FAILURE`- any of the tests failed

Not sure if you want it, from what I see executables are not supported. Though it is a really good way of checking if Swift runtime is doing what it is supposed to do.
