### PR TITLE
use swift-cmark/gfm for testing main

### DIFF
--- a/common.py
+++ b/common.py
@@ -34,7 +34,7 @@ branches = {
     'main': {
         'llvm-project': 'stable/20211026',
         'swift': 'main',
-        'cmark': 'main',
+        'cmark': 'gfm',
         'ninja': 'release',
         'llbuild': 'main',
         'swiftpm': 'main',


### PR DESCRIPTION
https://github.com/apple/swift/pull/40188 started building the Swift compiler with the `gfm` branch of swift-cmark, but the source-compat suite needs to be updated separately to point to that branch. This PR does that update.