### PR TITLE
Update `AsyncHTTPClient` to latest version `1.11.1`

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3177,8 +3177,8 @@
     "maintainer": "ktoso@apple.com",
     "compatibility": [
       {
-        "version": "5.0",
-        "commit": "a72c5adce3986ff6b5092ae0464a8f2675087860"
+        "version": "5.4",
+        "commit": "794dc9d42720af97cedd395e8cd2add9173ffd9a"
       }
     ],
     "platforms": [


### PR DESCRIPTION
Version `1.11.1` of `AsyncHTTPClient` only supports Swift 5.4+
https://github.com/swift-server/async-http-client/releases/tag/1.11.1

rdar://94044142