### PR TITLE
Re-enable swift-numerics

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3398,7 +3398,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "ae364a28f0eaf368b6a538a224d9ab20d88562c7"
+        "commit": "2624562948fd284a3e64ad9e96706f51d9a6a6e9"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -3408,15 +3408,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "swiftpm",
-        "xfail": [
-            {
-                "issue": "rdar://96437311",
-                "compatibility": "5.0",
-                "branch": ["main"],
-                "job": ["source-compat"]
-            }
-        ]
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
This project should be fixed by https://github.com/apple/swift/pull/60008 and https://github.com/apple/swift-numerics/pull/233.

Reverts apple/swift-source-compat-suite#678