### PR TITLE
Disable SRP on release/5.7

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2573,7 +2573,7 @@
             {
                 "issue": "rdar://91670339",
                 "compatibility": ["4.0"],
-                "branch": ["main"],
+                "branch": ["main", "release/5.7"],
                 "job": ["source-compat"]
             }
         ]


### PR DESCRIPTION
```
error: the Swift tools version specification is missing a label; consider inserting 'swift-tools-version:' between the comment marker and the version specifier
```