### PR TITLE
Parallelize project builds

### DIFF
--- a/build_incremental.py
+++ b/build_incremental.py
@@ -39,6 +39,7 @@ def main():
         args.include_repos,
         args.exclude_repos,
         args.verbose,
+        args.process_count,
         project.ProjectBuilder.factory(
             args.include_actions,
             args.exclude_actions,

--- a/builder.py
+++ b/builder.py
@@ -39,6 +39,7 @@ def main():
         args.include_repos,
         args.exclude_repos,
         args.verbose,
+        args.process_count,
         project.ProjectBuilder.factory(
             args.include_actions,
             args.exclude_actions,

--- a/runner.py
+++ b/runner.py
@@ -59,6 +59,7 @@ def main():
         args.include_repos,
         args.exclude_repos,
         args.verbose,
+        args.process_count,
         project.ProjectBuilder.factory(
             args.include_versions,
             args.exclude_versions,


### PR DESCRIPTION
### Pull Request Description

Parallelize project builds to speed up testing time significantly

As part of this PR
* Converted the factory pattern to use a `FactoryBuilder` object for handling object instantioation. This allows the factory pattern to be pickle-able which is required for multiprocessing support
* Implemented the `ProjectListBuilder.build()` function in order to parallelize the project builds across the desired number of processes
* Cleaned up some of the `XcodeTarget` logic which was printing various messages to stdout when it should have been printing to the log files. This became increasingly obvious/annoying after adding multiprocessing support


### **Factory work**
Previously we had a factory which basically encapsulated certain constructor args with a lambda. However, this is un-pickable from python standards which means none of those objects could be passed down to the multiprocessing support. From "[what can be pickled](https://docs.python.org/3/library/pickle.html#what-can-be-pickled-and-unpickled)"
> functions (built-in and user-defined) accessible from the top level of a module (using [def](https://docs.python.org/3/reference/compound_stmts.html#def), not [lambda](https://docs.python.org/3/reference/expressions.html#lambda));

Thus, I had to create an actual well defined object to house the constructor args which are used by the factory method. This makes the objects pickle-able and opens the door for multiprocessing support. This is the motivation behind `FactoryBuilder`


### **Multiprocessing**
We need to parallelize at the project level as to avoid conflicting git operations (you can't maintain two revisions of a git repo without maintaining two repositories), thus I implemented `ProjectListBuilder.build()` and was able to easily plug in the `concurrent.futures` library to do the heavy lifting with respect to the multi-processing of the project builds. I've included a configurable `--process-count` argument the end-user can override