### PR TITLE
Exclude armv7 and armv7s from iOS platform

### DIFF
--- a/project.py
+++ b/project.py
@@ -147,6 +147,8 @@ class XcodeTarget(ProjectTarget):
 
         if self._destination == 'generic/platform=watchOS':
             command += ['ARCHS=armv7k']
+        if self._destination == 'generic/platform=iOS':
+            command += ["EXCLUDED_ARCHS='armv7 armv7s'"]
 
         return command
 

--- a/project.py
+++ b/project.py
@@ -148,7 +148,7 @@ class XcodeTarget(ProjectTarget):
         if self._destination == 'generic/platform=watchOS':
             command += ['ARCHS=armv7k']
         if self._destination == 'generic/platform=iOS':
-            command += ["EXCLUDED_ARCHS='armv7 armv7s'"]
+            command += ['EXCLUDED_ARCHS=armv7 armv7s']
 
         return command
 


### PR DESCRIPTION
Fix issue with project building with armv7/armv7s

```
<unknown>:0: error: could not find module '_StringProcessing' for target 'armv7-apple-ios'; found: arm64e-apple-ios, arm64-apple-ios, at: /Users/ec2-user/jenkins/workspace-private/swift-main-source-compat-suite/build/compat_macos/install/toolchain/usr/lib/swift/iphoneos/_StringProcessing.swiftmodule

```

This started failing after https://github.com/apple/swift/pull/60363 (Dropping support for armv7/armv7s from iOS platform)