### PR TITLE
[Hotfix] Un-xfail Kingfisher and ReactiveKit after #688

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1249,15 +1249,7 @@
         "workspace": "Kingfisher.xcworkspace",
         "scheme": "Kingfisher",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/57435",
-            "compatibility": ["5.0"],
-            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2199,15 +2191,7 @@
         "workspace": "ReactiveKit.xcworkspace",
         "scheme": "ReactiveKit-iOS",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/57435",
-            "compatibility": ["5.0"],
-            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
-            "job": ["source-compat"]
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
We now skip armv7 and armv7s architecture (#688)

These projects only failed before for those specified architectures. This PR removes those xfails to prevent unexpected passes from occuring. 

Failing builds seen here:
https://ci.swift.org/job/swift-PR-source-compat-suite-test-macOS/38/
https://ci.swift.org/job/swift-PR-source-compat-suite-test-macOS/37/console

Verified locally that the `UPASS`'s no longer appear with this change