### PR TITLE
[NFC] Update readme & copyrights

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ integration system](https://ci.swift.org), allowing Swift compiler developers to
 understand the compatibility impact their changes have on real-world Swift
 projects.
 
+## Python Support
+The Source compatibility suite currently supports Python 3.8+. You may experience performance issues if you attempt to execute any of the associated files with a lesser version of Python 3.
+
 ## Current List of Projects
 
 The <a href="https://swift.org/source-compatibility/#current-list-of-projects">current list of projects</a> can be viewed on Swift.org.

--- a/build_incremental.py
+++ b/build_incremental.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/builder.py
+++ b/builder.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/checkout
+++ b/checkout
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/cleanup
+++ b/cleanup
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/common.py
+++ b/common.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/project.py
+++ b/project.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/project_precommit_check
+++ b/project_precommit_check
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/reproduce.py
+++ b/reproduce.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/run
+++ b/run
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/run_cperf
+++ b/run_cperf
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/runner.py
+++ b/runner.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information

--- a/utils/format_projects_list.py
+++ b/utils/format_projects_list.py
@@ -3,7 +3,7 @@
 #
 #  This source file is part of the Swift.org open source project
 #
-#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
 #  Licensed under Apache License v2.0 with Runtime Library Exception
 #
 #  See https://swift.org/LICENSE.txt for license information


### PR DESCRIPTION
### Pull Request Description

* Drop a note in the readme about Python 3.8 support as a result from #681
* Update recently touched files to bump the copyright to 2022 (A result from #681 and #687)

This is a non-functional change and does not affect any logic in the codebase