### PR TITLE
[Hotfix] Return results accordingly from the spawned process

### DIFF
--- a/project.py
+++ b/project.py
@@ -1002,7 +1002,7 @@ class ProjectListBuilder(ListBuilder):
         not inherit the default timeout from the parent process.
         """
         common.set_default_execute_timeout(default_timeout)
-        project_subbuilder.build()
+        return project_subbuilder.build()
 
     def build(self, stdout=sys.stdout):
         # Setup process pool to submit work to


### PR DESCRIPTION
### Pull Request Description

With the introduction of `start_process` from #693 , we just need to return the results accordingly from the function so they can be processed correctly.

Currently the function returns `None` since there is no return value
