### PR TITLE
Update swift-nio revision to include source fix

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3096,11 +3096,11 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "381fd99df2a2a95a13172b4b18880d4217274e23"
+        "commit": "f5448fbbc24495a6659ef64df4dd3c1fc4a0fb11"
       },
       {
         "version": "5.0",
-        "commit": "da23f751eee0d8287cc62824f6e0bc1f3ba2c0b6"
+        "commit": "f5448fbbc24495a6659ef64df4dd3c1fc4a0fb11"
       }
     ],
     "platforms": [
@@ -3114,9 +3114,9 @@
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
           {
-            "issue": "rdar://81180448",
-            "compatibility": ["4.2", "5.0"],
-            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+            "issue": "TODO-CREATE-A-NEW-RADAR",
+            "compatibility": ["4.2"],
+            "branch": ["main", "release/5.6", "release/5.7"],
             "job": ["source-compat"]
           }
         ]

--- a/projects.json
+++ b/projects.json
@@ -3095,10 +3095,6 @@
     "maintainer": "cbenfield@apple.com",
     "compatibility": [
       {
-        "version": "4.2",
-        "commit": "f5448fbbc24495a6659ef64df4dd3c1fc4a0fb11"
-      },
-      {
         "version": "5.0",
         "commit": "f5448fbbc24495a6659ef64df4dd3c1fc4a0fb11"
       }
@@ -3111,15 +3107,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift-nio/issues/2241",
-            "compatibility": ["4.2"],
-            "branch": ["main", "release/5.6", "release/5.7"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -3114,7 +3114,7 @@
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
           {
-            "issue": "TODO-CREATE-A-NEW-RADAR",
+            "issue": "https://github.com/apple/swift-nio/issues/2241",
             "compatibility": ["4.2"],
             "branch": ["main", "release/5.6", "release/5.7"],
             "job": ["source-compat"]


### PR DESCRIPTION
### Pull Request Description

* Updated swift-nio revision used by the compat suite to include fix for rdar://81180448, which was determined to be a project source error. This will allow us to test the project properly going forward.

ToDo: 
- [x] ~This uncovered a new build error with the 4.2 version. I will create a git issue and link it here~.
