### PR TITLE
Update swift-nio-ssl to latest HEAD.

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3274,7 +3274,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "6363cdf6d2fb863e82434f3c4618f4e896e37569"
+        "commit": "5c07eca3ac2cb05c26712dfc37e513412faf08fd"
       }
     ],
     "platforms": [


### PR DESCRIPTION
This resolves errors with expired certs in the tests.
