### PR TITLE
Xfail ACHNBrowserUI

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -27,7 +27,7 @@
             "issue": "https://github.com/apple/swift/issues/60577",
             "compatibility": ["5.0"],
             "branch": ["main"],
-            "job": ["stress-tester"]
+            "job": ["source-compat", "stress-tester"]
           }
         ]
       }

--- a/projects.json
+++ b/projects.json
@@ -28,6 +28,12 @@
             "compatibility": ["5.0"],
             "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
             "job": ["source-compat"]
+          },
+          {
+            "issue": "https://github.com/apple/swift/issues/60577",
+            "compatibility": ["5.0"],
+            "branch": ["main"],
+            "job": ["stress-tester"]
           }
         ]
       }


### PR DESCRIPTION
## In This PR
* Xfail ACHNBrowserUI which started failing after the LLVM branch update. 

Currently failing job: https://ci.swift.org/job/swift-main-sourcekitd-stress-tester/177/
