### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -21,7 +21,7 @@
         "target": "ACHNBrowserUI",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit sourcekit-smoke",
+        "tags": "sourcekit",
         "xfail": [
           {
             "issue": "https://github.com/apple/swift/issues/60577",

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -872,5 +872,167 @@
       "main"
     ],
     "issueUrl" : "https://github.com/apple/swift/issues/60528"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1475",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 367
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1475",
+    "issueDetail" : {
+      "kind" : "typeContextInfo",
+      "offset" : 367
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1475",
+    "issueDetail" : {
+      "kind" : "conformingMethodList",
+      "offset" : 367
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1999",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 1535
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1999",
+    "issueDetail" : {
+      "kind" : "typeContextInfo",
+      "offset" : 1535
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Guitar\/Sources\/GuitarCharacter.swift",
+    "modification" : "insideOut-1999",
+    "issueDetail" : {
+      "kind" : "conformingMethodList",
+      "offset" : 1535
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-279",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 12,
+      "offset" : 4
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-297",
+    "issueDetail" : {
+      "kind" : "cursorInfo",
+      "offset" : 77
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-299",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 16,
+      "offset" : 262
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-314",
+    "issueDetail" : {
+      "kind" : "cursorInfo",
+      "offset" : 278
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-319",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 24,
+      "offset" : 294
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-322",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 44,
+      "offset" : 278
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+  },
+  {
+    "path" : "*\/Result\/Result\/Result.swift",
+    "modification" : "concurrent-328",
+    "issueDetail" : {
+      "kind" : "editorReplaceText",
+      "length" : 0,
+      "offset" : 328,
+      "text" : "import"
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60702"
   }
 ]


### PR DESCRIPTION
- https://github.com/apple/swift/issues/60702 is a new issue
- ACHNBrowserUI fails to build and is thus currently failing the stress tester so remove it from `sourcekit-smoke`.