### PR TITLE
Add option to generate JUNIT reslts

### DIFF
--- a/project.py
+++ b/project.py
@@ -933,10 +933,10 @@ class ProjectListResult(ListResult):
 
     def xml_string(self):
         status_message = {
-            ResultEnum.PASS: 'This project passed. Emitting build log to save XML space',
+            ResultEnum.PASS: 'This project built successfully',
             ResultEnum.FAIL: 'This project failed to build',
-            ResultEnum.UPASS: 'This project built successfully, which was unexpected',
-            ResultEnum.XFAIL: 'This project failed to build as expected. Emitting build log to save XML space'
+            ResultEnum.UPASS: 'This project built successfully, but it was expected to fail',
+            ResultEnum.XFAIL: 'This project failed to build as expected'
         }
 
         action_results = self.recursive_all()
@@ -968,7 +968,7 @@ class ProjectListResult(ListResult):
             else:
                 xml_report += f"<testcase classname='build' name='{junit_testcase_name}'>\n"
                 xml_report += f"<failure type='failure' message='{status_message[action_result.result]}. " \
-                              f"{xfail_link}'>{build_log}</failure>"
+                              f"{xfail_link}'>Build log: {build_log}</failure>"
                 xml_report += "</testcase>\n"
 
         xml_report += "</testsuite>\n"

--- a/project.py
+++ b/project.py
@@ -941,7 +941,7 @@ class ProjectListResult(ListResult):
         test_cases = []
 
         for _pass in passes:
-            # Take everything after PASS:
+            # Parse everything after PASS:
             junit_case_name = _pass.text.split('PASS:')[1].strip()
 
             test_cases.append(
@@ -949,16 +949,18 @@ class ProjectListResult(ListResult):
             )
 
         for _xfail in xfails:
-            # Take everything after the first ',' (after the linked issue):
+            # Parse everything after the first ',' (after the linked issue):
             junit_case_name = _xfail.text.split(',', 1)[1].strip()
+            # Parse linked xfailure reason
+            xfail_link = _xfail.text.split("XFAIL:")[1].split(",")[0]
 
             test_cases.append(
                 TestCase(name=junit_case_name,
-                         stdout=f'This project failed as expected. See {_xfail.text.split("XFAIL:")[1].split(",")[0]}')
+                         stdout=f'This project failed as expected. See {xfail_link}')
             )
 
         for _fail in fails:
-            # Take everything after FAIL:
+            # Parse everything after FAIL:
             junit_case_name = _fail.text.split('FAIL:')[1].strip()
 
             test_case = TestCase(name=junit_case_name)
@@ -971,12 +973,15 @@ class ProjectListResult(ListResult):
             # Take everything after the first ',' (after the linked issue):
             junit_case_name = _upass.text.split(',', 1)[1].strip()
 
+            # Parse linked xfailure reason
+            xfail_link = _upass.text.split("UPASS:")[1].split(",")[0]
+
             test_case = TestCase(name=junit_case_name)
-            test_case.add_failure_info(message='This project built successfully, which was unexpected')
+            test_case.add_failure_info(message=f'This project built successfully, which was unexpected. '
+                                               f'Excepted failure: {xfail_link}')
             test_cases.append(test_case)
 
         ts = TestSuite("Source Compat Project Builds", test_cases)
-
         return to_xml_report_string([ts])
 
 

--- a/project.py
+++ b/project.py
@@ -808,9 +808,10 @@ class ResultEnum(Enum):
 
 
 class Result:
-    def __init__(self, result, text):
+    def __init__(self, result, text, logfile=None):
         self.result = result
         self.text = text
+        self.logfile = logfile
 
     def __str__(self):
         return self.result.name
@@ -1013,6 +1014,7 @@ class ListBuilder(Factory):
                     subbuilder_result = self.subbuilder.initialize(*([subtarget] + self.payload())).build(
                         stdout=output_fd
                     )
+                    subbuilder_result.logfile = log_filename
                     results.add(subbuilder_result)
                 finally:
                     if output_fd is not sys.stdout:

--- a/project.py
+++ b/project.py
@@ -961,23 +961,24 @@ class ProjectListResult(ListResult):
             # Take everything after FAIL:
             junit_case_name = _fail.text.split('FAIL:')[1].strip()
 
-            test_cases.append(
-                TestCase(name=junit_case_name,
-                         stderr=f'This project failed to build. <ATTACH BUILD LOG>')
-            )
+            test_case = TestCase(name=junit_case_name)
+            with open(f'{_fail}_{_fail.logfile}') as build_log:
+                test_case.add_failure_info(message=f'This project failed to build.',
+                                           output=build_log.read())
+            test_cases.append(test_case)
 
         for _upass in upasses:
             # Take everything after the first ',' (after the linked issue):
             junit_case_name = _upass.text.split(',', 1)[1].strip()
 
-            test_cases.append(
-                TestCase(name=junit_case_name,
-                         stderr=f'This project built succesfully, which was unexpected')
-            )
+            test_case = TestCase(name=junit_case_name)
+            test_case.add_failure_info(message='This project built successfully, which was unexpected')
+            test_cases.append(test_case)
 
         ts = TestSuite("Source Compat Project Builds", test_cases)
 
         return to_xml_report_string([ts])
+
 
 class ProjectResult(ListResult):
     pass

--- a/runner.py
+++ b/runner.py
@@ -90,6 +90,12 @@ def main():
         index
     ).build()
     common.debug_print(str(result))
+
+    # Write Junit (ToDo: Wrap this around a flag)
+    xml = result.xml_string()
+    with open('results.xml', 'w') as results:
+        results.write(xml)
+
     return 0 if result.result in [project.ResultEnum.PASS,
                                   project.ResultEnum.XFAIL] else 1
 

--- a/runner.py
+++ b/runner.py
@@ -91,10 +91,9 @@ def main():
     ).build()
     common.debug_print(str(result))
 
-    # Write Junit (ToDo: Wrap this around a flag)
-    xml = result.xml_string()
-    with open('results.xml', 'w') as results:
-        results.write(xml)
+    if args.junit:
+        with open('results.xml', 'w') as results:
+            results.write(result.xml_string())
 
     return 0 if result.result in [project.ResultEnum.PASS,
                                   project.ResultEnum.XFAIL] else 1


### PR DESCRIPTION
## In This PR
Added JUNIT functionality to the `ProjectListResult` so users of `runner.py` can generate Junit results as needed. This will make CI jobs much easier to reason through and make identifying failures much easier.

* Updated Results objects to contain a link to their build log if it exists
* Added Junit functionality to `ProjectListResult`. Each junit test case simply adds a link to the jenkins artifact in the stdout. This will save XML space significantly
* Wrapped JUINT functionality behind `--junit` flag. No current consumers of the project will see changes until they pass the `--junit` flag appropriately