### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -21,7 +21,7 @@
         "target": "ACHNBrowserUI",
         "destination": "generic/platform=iOS",
         "configuration": "Release",
-        "tags": "sourcekit"
+        "tags": "sourcekit sourcekit-smoke"
       }
     ]
   },

--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -717,44 +717,6 @@
     "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-298",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 12,
-      "offset" : 4
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-316",
-    "issueDetail" : {
-      "kind" : "cursorInfo",
-      "offset" : 77
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-318",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 16,
-      "offset" : 262
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/extensions\/View.swift",
     "modification" : "unmodified",
     "issueDetail" : {
@@ -1015,20 +977,6 @@
       "kind" : "rangeInfo",
       "length" : 44,
       "offset" : 278
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
-  },
-  {
-    "path" : "*\/Result\/Result\/Result.swift",
-    "modification" : "concurrent-328",
-    "issueDetail" : {
-      "kind" : "editorReplaceText",
-      "length" : 0,
-      "offset" : 328,
-      "text" : "import"
     },
     "applicableConfigs" : [
       "main"


### PR DESCRIPTION
- ACHNBrowserUI is building in the source compatibility suite again now, so we can add it to the stress tester projects as well
- Some XFails are no longer failing, remove them
