### PR TITLE
Fix a Python exception that occurred while running the SourceKit stress tester

### DIFF
--- a/project.py
+++ b/project.py
@@ -1008,7 +1008,8 @@ class ListBuilder(Factory):
                     subbuilder_result = self.subbuilder.initialize(*([subtarget] + self.payload())).build(
                         stdout=output_fd
                     )
-                    subbuilder_result.logfile = log_filename
+                    if subbuilder_result:
+                        subbuilder_result.logfile = log_filename
                     results.add(subbuilder_result)
                 finally:
                     if output_fd is not sys.stdout:


### PR DESCRIPTION
For reasons I don’t fully understand `subbuilder_result` can be `None`, so we can’t assign the `logfile` property here. This caused the stress tester to fail with the following error: (https://ci.swift.org/job/swift-main-sourcekitd-stress-tester/191/console)
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/concurrent/futures/process.py", line 243, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "/Users/ec2-user/jenkins/workspace/swift-main-sourcekitd-stress-tester/swift-source-compat-suite/project.py", line 1052, in start_process
    return project_subbuilder.build()
  File "/Users/ec2-user/jenkins/workspace/swift-main-sourcekitd-stress-tester/swift-source-compat-suite/project.py", line 1008, in build
    subbuilder_result = self.subbuilder.initialize(*([subtarget] + self.payload())).build(
  File "/Users/ec2-user/jenkins/workspace/swift-main-sourcekitd-stress-tester/swift-source-compat-suite/project.py", line 1011, in build
    subbuilder_result.logfile = log_filename
AttributeError: 'NoneType' object has no attribute 'logfile'
```


I’m just adding an `if` here to work around the crash to get the stress tester passing, there might be a more fundamental fix, but I don’t think I’ve got the capacity right now to chase it down.

Caused by https://github.com/apple/swift-source-compat-suite/pull/705