### PR TITLE
remove swift syntax directory

### DIFF
--- a/cleanup
+++ b/cleanup
@@ -66,6 +66,7 @@ def main():
         'swift-numerics',
         'swift-system',
         'swift-experimental-string-processing',
+        'swift-syntax',
     ]
 
     if args.cleanup_cache:


### PR DESCRIPTION
## In This PR
* Remove swift-syntax from build directory.

Will fix https://ci.swift.org/job/swift-main-sourcekitd-stress-tester/198/