### PR TITLE
Remove linux based xfail for Doggie after compiler fix

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -690,14 +690,6 @@
                 "compatibility": "5.0",
                 "branch": ["release/5.5"],
                 "job": ["source-compat"]
-            },
-            {
-                "issue": "https://github.com/apple/swift/issues/60877",
-                "compatibility": "5.0",
-                "platform": "Linux",
-                "configuration": "release",
-                "branch": ["main"],
-                "job": ["source-compat"]
             }
         ]
       },


### PR DESCRIPTION
## In This PR
* Remove xfail for compiler crash on linux. The fix was landed here: https://github.com/apple/swift/pull/60902

Will close the associated swift issue once this is merged.

I've verified the issue is fixed with the newest `swiftlang/swift:nightly-focal` docker image. You can see the project UPASSing here on CI: https://ci.swift.org/job/swift-source-compat-suite-ubuntu-2004/56/testReport/junit/(root)/build/_Doggie__5_0__965946__Swift_Package/
