### PR TITLE
Write regular strings to file

### DIFF
--- a/run_cperf
+++ b/run_cperf
@@ -592,7 +592,7 @@ def parse_args():
     parser.add_argument('--skip-runner',
                         action='store_true')
     parser.add_argument('--output',
-                        type=argparse.FileType('wb', 0),
+                        type=argparse.FileType('w'),
                         default=get_default_output('comment.md'))
     parser.add_argument('--clean',
                         action='store_true')


### PR DESCRIPTION
### Pull Request Description
* Fix cperf writing strings to a file, not bytes

This popped up after we recently updated the compiler performance jobs to use python3.
https://ci.swift.org/job/swift-PR-compiler-performance-macOS/42/