### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -417,17 +417,6 @@
     "issueUrl" : "https://github.com/apple/swift/issues/57045"
   },
   {
-  "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/categories\/CategoriesView.swift",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 602
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/57237"
-  },
-  {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/userLists\/UserListDetailView.swift",
     "issueDetail" : {
       "kind" : "codeComplete",
@@ -644,80 +633,6 @@
   },
   {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/turnips\/charts\/TurnipsChart.swift",
-    "modification" : "insideOut-225",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 199
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-212",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 60
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-213",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 61
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-217",
-    "issueDetail" : {
-      "kind" : "cursorInfo",
-      "offset" : 61
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-217",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 5,
-      "offset" : 60
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-219",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 154,
-      "offset" : 65
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/turnips\/charts\/TurnipsChart.swift",
     "modification" : "insideOut-177",
     "issueDetail" : {
       "kind" : "cursorInfo",
@@ -741,21 +656,70 @@
     "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-279",
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/viewModels\/ItemsViewModel.swift",
+    "modification" : "insideOut-496",
     "issueDetail" : {
       "kind" : "rangeInfo",
-      "length" : 12,
-      "offset" : 4
+      "length" : 13,
+      "offset" : 135
     },
     "applicableConfigs" : [
       "main"
     ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
     "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-297",
+    "modification" : "insideOut-253",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 72
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-254",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 73
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-258",
+    "issueDetail" : {
+      "kind" : "cursorInfo",
+      "offset" : 73
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-258",
+    "issueDetail" : {
+      "kind" : "rangeInfo",
+      "length" : 5,
+      "offset" : 72
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
+  },
+  {
+    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
+    "modification" : "insideOut-276",
     "issueDetail" : {
       "kind" : "cursorInfo",
       "offset" : 77
@@ -763,11 +727,11 @@
     "applicableConfigs" : [
       "main"
     ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
     "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-299",
+    "modification" : "insideOut-278",
     "issueDetail" : {
       "kind" : "rangeInfo",
       "length" : 16,
@@ -776,44 +740,6 @@
     "applicableConfigs" : [
       "main"
     ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-314",
-    "issueDetail" : {
-      "kind" : "cursorInfo",
-      "offset" : 278
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-319",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 24,
-      "offset" : 294
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
-  },
-  {
-    "path" : "*\/MovieSwift\/MovieSwift\/MovieSwift\/views\/components\/discover\/DraggableCover.swift",
-    "modification" : "insideOut-322",
-    "issueDetail" : {
-      "kind" : "rangeInfo",
-      "length" : 44,
-      "offset" : 278
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60702"
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
   }
 ]


### PR DESCRIPTION
- https://github.com/apple/swift/issues/57237 has been fixed
- A couple of timeouts stopped occurring and a couple new timeouts started ocurring, most likely due to the switch to the new parser
