### PR TITLE
[WIP] Build Tests With Swift Packages

### DIFF
--- a/project.py
+++ b/project.py
@@ -292,7 +292,8 @@ def build_swift_package(path, swiftc, swift_version, configuration,
                         sandbox_profile, stdout=sys.stdout, stderr=sys.stderr,
                         added_swift_flags=None,
                         incremental=False,
-                        override_swift_exec=None):
+                        override_swift_exec=None,
+                        build_tests=False):
     """Build a Swift package manager project."""
     swift = os.path.join(os.path.dirname(swiftc), 'swift')
     if not incremental:
@@ -306,6 +307,10 @@ def build_swift_package(path, swiftc, swift_version, configuration,
     if (swift_branch not in ['swift-3.0-branch',
                              'swift-3.1-branch']):
         command.insert(2, '--disable-sandbox')
+
+    if build_tests:
+        command += ['--build-tests']
+        added_swift_flags += ' -enable-testing'
 
     if swift_version:
         if '.' not in swift_version:
@@ -409,7 +414,8 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
                                    stdout=stdout, stderr=stderr,
                                    added_swift_flags=added_swift_flags,
                                    incremental=incremental,
-                                   override_swift_exec=override_swift_exec)
+                                   override_swift_exec=override_swift_exec,
+                                   build_tests=action.get('build_tests') == 'true')
     elif action['action'] == 'TestSwiftPackage':
         return test_swift_package(os.path.join(root_path, repo['path']),
                                   swiftc,

--- a/projects.json
+++ b/projects.json
@@ -193,6 +193,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -223,6 +224,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "debug",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -319,6 +321,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -607,6 +610,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit sourcekit-smoke swiftpm"
       },
@@ -634,6 +638,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -682,6 +687,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm",
         "xfail": [
@@ -851,7 +857,16 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "build_tests": "true",
+        "xfail": [
+          {
+            "issue": "ToDo: This project fails to build tests. Will pass with a newer source revision. File issue",
+            "compatibility": ["4.2", "5.0"],
+            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+            "job": ["source-compat"]
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -876,6 +891,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -899,6 +915,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -926,6 +943,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -953,6 +971,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit sourcekit-smoke swiftpm"
       },
@@ -984,6 +1003,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1289,6 +1309,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
@@ -1359,6 +1380,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1389,6 +1411,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -1473,6 +1496,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -1504,6 +1528,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -1559,6 +1584,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1611,6 +1637,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1717,6 +1744,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1744,12 +1772,19 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
             {
                 "issue": "rdar://83373864",
                 "platform": "Linux",
+                "compatibility": "4.2",
+                "branch": ["main", "release/5.6", "release/5.7"],
+                "job": ["source-compat"]
+            },
+            {
+                "issue": "ToDo: Create an issue for this. Tests failed to build. Passes with a revision update",
                 "compatibility": "4.2",
                 "branch": ["main", "release/5.6", "release/5.7"],
                 "job": ["source-compat"]
@@ -1795,6 +1830,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -1840,6 +1876,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -1987,8 +2024,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "ToDo: This project fails to build tests. File issue",
+            "compatibility": ["4.2", "5.0"],
+            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+            "job": ["source-compat"]
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -2198,6 +2244,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -2281,6 +2328,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit sourcekit-smoke swiftpm"
       },
@@ -2307,6 +2355,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       }
@@ -2527,6 +2576,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
@@ -2571,8 +2621,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+            {
+                "issue": "ToDo: This project fails to build tests. File issue",
+                "compatibility": ["4.2", "5.0"],
+                "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+                "job": ["source-compat"]
+            }
+        ]
       }
     ]
   },
@@ -2594,6 +2653,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -2771,7 +2831,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "build_tests": "true",
+        "build_tests": "false. TODO. File issue to figure out why this hangs forever",
         "tags": "swiftpm"
       },
       {
@@ -2872,6 +2932,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release"
       },
       {
@@ -2906,6 +2967,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -2933,8 +2995,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "ToDo: This project fails to build tests. File issue",
+            "compatibility": ["4.0", "4.2"],
+            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+            "job": ["source-compat"]
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -2960,6 +3031,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
@@ -3065,6 +3137,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -3160,6 +3233,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -3413,6 +3487,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
@@ -3678,6 +3753,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -3708,6 +3784,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
@@ -3852,6 +3929,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm"
       },
@@ -3956,6 +4034,7 @@
       },
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
@@ -3991,6 +4070,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4015,6 +4095,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4039,6 +4120,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4063,6 +4145,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4087,6 +4170,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4111,8 +4195,17 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "ToDo: This project fails to build tests. File issue",
+            "compatibility": ["4.2"],
+            "branch": ["main", "release/5.5", "release/5.6", "release/5.7"],
+            "job": ["source-compat"]
+          }
+        ]
       }
     ]
   },
@@ -4135,6 +4228,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4159,6 +4253,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4183,6 +4278,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       }
@@ -4232,6 +4328,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
+        "build_tests": "true",
         "configuration": "release",
         "tags": "swiftpm",
         "xfail": [

--- a/projects.json
+++ b/projects.json
@@ -3237,7 +3237,7 @@
       },
       {
         "version": "5.0",
-        "commit": "66f9a509ed3cc56b6eb367515e421beca4a0af53"
+        "commit": "55f37f388c2cbe717395176fbe8984354d8488d2"
       }
     ],
     "platforms": [
@@ -3448,7 +3448,15 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "swiftpm"
+        "tags": "swiftpm",
+        "xfail": [
+          {
+            "issue": "Tests fail to build with --build-tests on the release config <ToDo: Add Radar>",
+            "compatibility": ["5.0"],
+            "configuration": "release",
+            "branch": ["main", "release/5.6", "release/5.7"]
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"
@@ -3492,7 +3500,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "0fd434556ce4c66bc803e867f6903587c69e55a2"
+        "commit": "e9619146a1198253c587f6f34c0869d3a98b0c76"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -2716,6 +2716,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -2742,6 +2743,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -2769,6 +2771,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -2795,7 +2798,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release"
+        "configuration": "release",
+        "build_tests": "true"
       },
       {
         "action": "TestSwiftPackage"
@@ -3093,6 +3097,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm",
         "xfail": [
           {
@@ -3128,6 +3133,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3182,6 +3188,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3209,6 +3216,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3240,6 +3248,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3267,6 +3276,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3294,6 +3304,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3321,6 +3332,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3348,6 +3360,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3374,6 +3387,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -3433,6 +3447,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -3460,6 +3475,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -3487,6 +3503,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "sourcekit-disabled swiftpm"
       },
       {
@@ -4244,6 +4261,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {
@@ -4271,6 +4289,7 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
+        "build_tests": "true",
         "tags": "swiftpm"
       },
       {


### PR DESCRIPTION
## In This PR
* Build tests for all `SwiftPackage`'s by passing `--build-tests` when appropriate

By building tests we expand our verification coverage greatly. This PR does not enable any test execution. Initial PR open to gather timing results.
