### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -743,18 +743,6 @@
     "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
-    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/extensions\/Path.swift",
-    "modification" : "insideOut-893",
-    "issueDetail" : {
-      "kind" : "codeComplete",
-      "offset" : 884
-    },
-    "applicableConfigs" : [
-      "main"
-    ],
-    "issueUrl" : "https://github.com/apple/swift/issues/60192"
-  },
-  {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/categories\/CategoriesView.swift",
     "modification" : "unmodified",
     "issueDetail" : {


### PR DESCRIPTION
- insideOut-893 is known to be flaky but recently it hasn’t occurred. Let’s remove it while we’re investigating why it’s flaky.
