### PR TITLE
+add Distributed Actors

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -107,6 +107,13 @@ supported_configs = {
                        'Target: x86_64-apple-darwin20.3.0\n',
             'description': 'Xcode 12.4 (contains Swift 5.3.2)',
             'branch': 'swift-5.3-branch'
+        },
+        '5.7': {
+            'version': 'Apple Swift version 5.7.0 '
+                       '(swiftlang-5.7.0.123.8 clang-1400.0.29.50)\n'
+                       'Target: x86_64-apple-darwin22.3.0\n',
+            'description': 'Xcode 14.0 (contains Swift 5.7.0)',
+            'branch': 'swift-5.7-branch'
         }
     },
     # NOTE: Linux isn't fully supported yet

--- a/projects.json
+++ b/projects.json
@@ -3163,7 +3163,7 @@
     "compatibility": [
       {
         "version": "5.7",
-        "commit": "d816a10b70a6d537b2aa666ff735888b7ba40ab4"
+        "commit": "e024c1fae5d2b17346c8a2c4482675a70f35fccc"
       }
     ],
     "platforms": [
@@ -3173,7 +3173,8 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "debug",
+        "build_tests": "true",
+        "configuration": "release",
         "tags": "sourcekit-disabled swiftpm"
       },
       {

--- a/projects.json
+++ b/projects.json
@@ -3156,6 +3156,33 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/apple/swift-distributed-actors",
+    "path": "swift-distributed-actors",
+    "branch": "main",
+    "maintainer": "ktoso@apple.com",
+    "compatibility": [
+      {
+        "version": "5.7",
+        "commit": "d816a10b70a6d537b2aa666ff735888b7ba40ab4"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/swift-server/async-http-client",
     "path": "async-http-client",
     "branch": "main",

--- a/projects.json
+++ b/projects.json
@@ -3173,7 +3173,7 @@
     "actions": [
       {
         "action": "BuildSwiftPackage",
-        "configuration": "release",
+        "configuration": "debug",
         "tags": "sourcekit-disabled swiftpm"
       },
       {


### PR DESCRIPTION
### Pull Request Description

Now that swift 5.7 is stable we really should be testing the distributed actors cluster because it is the large codebase pushing both swift concurrency and the distributed feature.

https://github.com/apple/swift-distributed-actors

This requires 5.7 so we need to add that Swuft support... not entirely sure how to do that, will reach out to someone.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
    - it uses language features which require 5.7, so that's the minimum version
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* Apache License, version 2.0
- [x] pass `./project_precommit_check` script run
    - TODO
