### PR TITLE
Add flaky ACHNBrowserUI timeout

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -743,6 +743,18 @@
     "issueUrl" : "https://github.com/apple/swift/issues/60192"
   },
   {
+    "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/extensions\/Path.swift",
+    "modification" : "insideOut-893",
+    "issueDetail" : {
+      "kind" : "codeComplete",
+      "offset" : 884
+    },
+    "applicableConfigs" : [
+      "main"
+    ],
+    "issueUrl" : "https://github.com/apple/swift/issues/60192"
+  },
+  {
     "path" : "*\/ACHNBrowserUI\/ACHNBrowserUI\/ACHNBrowserUI\/views\/categories\/CategoriesView.swift",
     "modification" : "unmodified",
     "issueDetail" : {


### PR DESCRIPTION
`ACHNBrowserUI/extensions/Path.swift` has wildly different run times depending on the run. The stress tester has now been updated to always give it a soft timeout (ffb5a01e22683b0a1419b6fd775bb45af50660fb). Add the xfail back in.