### PR TITLE
common.py: bump Yams to 5.0.1

### DIFF
--- a/common.py
+++ b/common.py
@@ -38,7 +38,7 @@ branches = {
         'swift-corelibs-xctest': 'main',
         'swift-argument-parser': '1.0.3',
         'swift-driver': 'main',
-        'yams': '4.0.2',
+        'yams': '5.0.1',
         'swift-tools-support-core': 'main',
         'swift-crypto': '1.1.5',
         'swift-atomics': '1.0.2',


### PR DESCRIPTION
This fixes an issue resolved in jpsim/Yams#353, which is currently blocking apple/swift-package-manager#5894.