### PR TITLE
Bump `swift-argument-parser` to 1.1.4

### DIFF
--- a/common.py
+++ b/common.py
@@ -36,7 +36,7 @@ branches = {
         'swift-corelibs-libdispatch': 'main',
         'swift-corelibs-foundation': 'main',
         'swift-corelibs-xctest': 'main',
-        'swift-argument-parser': '1.0.3',
+        'swift-argument-parser': '1.1.4',
         'swift-driver': 'main',
         'yams': '5.0.1',
         'swift-tools-support-core': 'main',


### PR DESCRIPTION
This PR is accompanied by https://github.com/apple/swift/pull/59009 https://github.com/apple/swift-driver/pull/1218 https://github.com/apple/swift-package-manager/pull/5884 https://github.com/apple/sourcekit-lsp/pull/673 and should be merged synchronously with those.