### PR TITLE
Remove Evergreen

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -807,43 +807,6 @@
   },
   {
     "repository": "Git",
-    "url": "https://github.com/brentsimmons/Evergreen.git",
-    "path": "Evergreen",
-    "branch": "main",
-    "maintainer": "brent@ranchero.com",
-    "compatibility": [
-      {
-        "version": "4.0",
-        "commit": "ce0d2450b83ec8c5dee6bb9c612b3eb06ba39c47"
-      }
-    ],
-    "platforms": [
-      "Darwin"
-    ],
-    "actions": [
-      {
-        "action": "BuildXcodeWorkspaceScheme",
-        "workspace": "Evergreen.xcworkspace",
-        "scheme": "Evergreen",
-        "destination": "generic/platform=macOS",
-        "environment": {
-            "ARCHS": "x86_64"
-        },
-        "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/57432",
-            "compatibility": ["4.0"],
-            "branch": ["main", "release/5.5", "release/5.6", "release/5.7", "release/5.8"],
-            "job": ["source-compat"]
-          }
-        ]
-      }
-    ]
-  },
-  {
-    "repository": "Git",
     "url": "https://github.com/exercism/swift.git",
     "path": "exercism-swift",
     "branch": "main",


### PR DESCRIPTION
The Git URL of Evergreen (https://github.com/brentsimmons/Evergreen.git) no longer exists, it redirects to NetNewsWire. This is causing failures in CI during clone ([swift-main-source-compat-suite-debug](https://ci.swift.org/job/swift-main-source-compat-suite-debug/307/)). 

Since the project has also been renamed and there is no longer an Xcode workspace, I’m not sure if they are the same projects. If NetNewsWire should be part of the source compat suite, it should be added again.