### PR TITLE
Revert "Xfail rxswift https://github.com/apple/swift/issues/63242"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2407,64 +2407,28 @@
         "scheme": "RxRelay",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxRelay",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxRelay",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxRelay",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2472,64 +2436,28 @@
         "scheme": "RxCocoa",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxCocoa",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
@@ -2537,64 +2465,28 @@
         "scheme": "RxBlocking",
         "destination": "platform=macOS",
         "configuration": "Release",
-        "tags": "sourcekit-disabled",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "tags": "sourcekit-disabled"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxBlocking",
         "destination": "generic/platform=iOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxBlocking",
         "destination": "generic/platform=tvOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",
         "workspace": "Rx.xcworkspace",
         "scheme": "RxBlocking",
         "destination": "generic/platform=watchOS",
-        "configuration": "Release",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/63242",
-            "compatibility": ["5.0"],
-            "branch": ["main"],
-            "job": ["source-compat"],
-            "configuration": "release"
-          }
-        ]
+        "configuration": "Release"
       },
       {
         "action": "BuildXcodeWorkspaceScheme",


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#759

Should have been fixed by https://github.com/apple/swift/pull/63266.