### PR TITLE
[swift-nio] Drop 4.2 configuration and un-XFAIL 5.0 since perf issue …

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3094,10 +3094,6 @@
     "maintainer": "cbenfield@apple.com",
     "compatibility": [
       {
-        "version": "4.2",
-        "commit": "381fd99df2a2a95a13172b4b18880d4217274e23"
-      },
-      {
         "version": "5.0",
         "commit": "e855380cb5234e96b760d93e0bfdc403e381e928"
       }
@@ -3111,15 +3107,7 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": [
-          {
-            "issue": "rdar://81180448",
-            "compatibility": ["4.2", "5.0"],
-            "branch": ["main", "release/5.5", "release/5.6", "release/5.7", "release/5.8"],
-            "job": ["source-compat"]
-          }
-        ]
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
…has been addressed

5.0 configuration is currently UPASS'ing in the suite and 4.2 is no longer supported per https://github.com/apple/swift-nio/issues/2241.