### PR TITLE
xfail distributed cluster on release builds; we use @testable for teskit

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3162,11 +3162,12 @@
       {
         "action": "BuildSwiftPackage",
         "build_tests": "true",
-        "configuration": "release",
-        "tags": "sourcekit-disabled swiftpm"
-      },
-      {
-        "action": "TestSwiftPackage"
+        "configuration": "debug",
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": {
+          "issue": "https://github.com/apple/swift-distributed-actors/issues/1113",
+          "configuration": "release"
+        }
       }
     ]
   },


### PR DESCRIPTION
Resolves rdar://106086239
Related issue to rework the testkit: https://github.com/apple/swift-distributed-actors/issues/1113 

We can't `swift build -c release` the testkit target, it is only used in testing though. Potentially we could remove it entirely now that Swift gained async await and actors, but that's a large piece of work.
