### PR TITLE
Fix source compat swift builds

### DIFF
--- a/common.py
+++ b/common.py
@@ -257,14 +257,6 @@ def clone_repos():
         '{}/swift-crypto '.format(
             branches[swift_branch]['swift-crypto'], workspace
         ),
-        '{} git@github.com:apple/swift-asn1.git '
-        '{}/swift-asn1 '.format(
-            branches[swift_branch]['swift-asn1'], workspace
-        ),
-        '{} git@github.com:apple/swift-certificates.git '
-        '{}/swift-certificates '.format(
-            branches[swift_branch]['swift-certificates'], workspace
-        ),
         '{} git@github.com:apple/swift-atomics.git '
         '{}/swift-atomics '.format(
             branches[swift_branch]['swift-atomics'], workspace
@@ -296,6 +288,19 @@ def clone_repos():
             '{} git@github.com:apple/swift-syntax.git '
             '{}/swift-syntax '.format(
                 branches[swift_branch]['swift-syntax'], workspace
+            ),
+        ]
+
+    if swift_branch not in ['release/5.8', 'release/5.7', 'release/5.6',
+                            'release/5.5', 'release/5.4']:
+        repos += [
+            '{} git@github.com:apple/swift-asn1.git '
+            '{}/swift-asn1 '.format(
+                branches[swift_branch]['swift-asn1'], workspace
+            ),
+            '{} git@github.com:apple/swift-certificates.git '
+            '{}/swift-certificates '.format(
+                branches[swift_branch]['swift-certificates'], workspace
             ),
         ]
 

--- a/common.py
+++ b/common.py
@@ -26,8 +26,8 @@ DEFAULT_EXECUTE_TIMEOUT = 10*60
 
 branches = {
     'main': {
-        'llvm-project': 'stable/20220421',
-        'swift-llvm-bindings': 'stable/20220421',
+        'llvm-project': 'stable/20221013',
+        'swift-llvm-bindings': 'stable/20221013',
         'swift': 'main',
         'cmark': 'gfm',
         'ninja': 'release',


### PR DESCRIPTION
### Pull Request Description

* Fix build issue due to mismatched LLVM version, `stable/20220421` does not contain the LLVM cmake function `llvm_add_tool_symlink` causing builds to fail.
* Fix builds on all branches != `main` after [`b933299efa73fa3ecf78f7b2d5769596b3a66fe6`](https://github.com/apple/swift-source-compat-suite/commit/b933299efa73fa3ecf78f7b2d5769596b3a66fe6)

On any branches which don't need to clone `swift-asn1` and `swift-certificates` the build shouldn't clone those branches