### PR TITLE
unxfail swift-nio after --build-tests removed from release builds

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3110,16 +3110,7 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": [
-            {
-                "issue": "https://github.com/apple/swift/issues/64247",
-                "platform": "Linux",
-                "compatibility": "5.0",
-                "branch": ["main"],
-                "job": ["source-compat"]
-            }
-        ]
+        "tags": "sourcekit-disabled swiftpm"
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description
swift-nio only encounters a compiler crash when building the release config with --build-tests, which was recently removed in favor of only building tests in debug configs.

The issue is still real, so I will leave the associated swift issue open