### PR TITLE
xfail swift-cluster-membership (debug) - fails with x86_64

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3547,7 +3547,17 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "https://github.com/apple/swift/issues/61622",
+            "platform": "Darwin",
+            "compatibility": ["5.0"],
+            "branch": ["main", "release/5.5", "release/5.6", "release/5.7", "release/5.8"],
+            "job": ["source-compat"],
+            "configuration": "debug"
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
### Pull Request Description

* Mistakenly removed this xfail as it passed locally (arm). This still fails in CI, the xfail should remain