### PR TITLE
Revert "xfail distributed cluster on release builds; we use @testable…

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3173,12 +3173,11 @@
       {
         "action": "BuildSwiftPackage",
         "build_tests": "true",
-        "configuration": "debug",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": {
-          "issue": "https://github.com/apple/swift-distributed-actors/issues/1113",
-          "configuration": "release"
-        }
+        "configuration": "release",
+        "tags": "sourcekit-disabled swiftpm"
+      },
+      {
+        "action": "TestSwiftPackage"
       }
     ]
   },


### PR DESCRIPTION
### Pull Request Description
The xfail

```
        "xfail": {
          "issue": "https://github.com/apple/swift-distributed-actors/issues/1113",
          "configuration": "release"
        }
```

Doesn't actually xfail anything since the `compatibility` flag is omitted. The project is passing on main, and so this xfail isn't needed

