### PR TITLE
Build projects in debug config when stress testing

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -300,6 +300,7 @@ class StressTesterRunner(object):
           '--swift-branch', self.swift_branch,
           '--job-type', 'stress-tester',
           '--default-timeout', str(-1),
+          '--build-config', 'debug',
           '--only-latest-versions',
           # Don't build projects in parallel because stress testing a single project already utilises the CPU 100% and stress testing multiple causes timeouts.
           '--process-count', '1',


### PR DESCRIPTION
Tests are only built when the project is built in debug config and to get test coverage for those as well, we should be building for debug when running the stress tester.
