### PR TITLE
Add Graphiti and GraphQL projects

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -871,6 +871,54 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/GraphQLSwift/Graphiti.git",
+    "path": "Graphiti",
+    "branch": "main",
+    "maintainer": "clack@passivelogic.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "64b180e08fe6dcd48d17485f167b8a49c16ad9e9"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "build_tests": "true",
+        "configuration": "release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/GraphQLSwift/GraphQL.git",
+    "path": "GraphQL",
+    "branch": "main",
+    "maintainer": "clack@passivelogic.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "7c910f22508b918900c7a91e53638184dc6504d4"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "build_tests": "true",
+        "configuration": "release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/groue/GRDB.swift.git",
     "path": "GRDB.swift",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Adds both Graphiti and GraphQL projects to the suite.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* MIT
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

Graphiti
```
PASS: Graphiti, 5.0, 64b180, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- Graphiti checked successfully against Swift 5.0 ---
```

GraphQL
```
PASS: GraphQL, 5.0, 7c910f, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- GraphQL checked successfully against Swift 5.0 ---
```