### PR TITLE
Add Smtp project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2587,6 +2587,30 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/Mikroservices/Smtp.git",
+    "path": "Smtp",
+    "branch": "master",
+    "maintainer": "clack@passivelogic.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "e8f09e1715bdb88499b2722dbd1df140be475d1a"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "build_tests": "true",
+        "configuration": "release"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/krzysztofzablocki/Sourcery.git",
     "path": "Sourcery",
     "branch": "master",


### PR DESCRIPTION
### Pull Request Description

Adds Smtp project to the suite - https://github.com/Mikroservices/Smtp.

Note that a recent compiler regression was discovered when building this project in release mode. https://github.com/apple/swift/issues/64219

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* MIT
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

```
PASS: Smtp, 5.0, e8f09e, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
```