### PR TITLE
Add GRDB+Swift 5.7

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -877,24 +877,20 @@
     "compatibility": [
       {
         "version": "4.2",
-        "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
+        "commit": "5ee47c3c2765bdfde0f44c2ea9a263f6aa252d63"
       },
       {
-        "version": "5.0",
-        "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
+        "version": "5.1",
+        "commit": "5ee47c3c2765bdfde0f44c2ea9a263f6aa252d63"
       },
-       {
-         "version": "5.1",
-         "commit": "d290102d9cb5c425fee7260034beaa997d581d86"
-       },
-       {
-         "version": "5.3",
-         "commit": "dd7e7f39e8e4d7a22d258d9809a882f914690b01"
-       },
-       {
-         "version": "5.7",
-         "commit": "2d19cab2b525f885ee8d7efec96093431f6b5f20"
-       }
+      {
+        "version": "5.3",
+        "commit": "dd7e7f39e8e4d7a22d258d9809a882f914690b01"
+      },
+      {
+        "version": "5.7",
+        "commit": "2d19cab2b525f885ee8d7efec96093431f6b5f20"
+      }
     ],
     "platforms": [
       "Darwin"

--- a/projects.json
+++ b/projects.json
@@ -878,7 +878,23 @@
       {
         "version": "4.2",
         "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
-      }
+      },
+      {
+        "version": "5.0",
+        "commit": "759c1088a1d9ba94f44009295fd17c20b1375524"
+      },
+       {
+         "version": "5.1",
+         "commit": "d290102d9cb5c425fee7260034beaa997d581d86"
+       },
+       {
+         "version": "5.3",
+         "commit": "dd7e7f39e8e4d7a22d258d9809a882f914690b01"
+       },
+       {
+         "version": "5.7",
+         "commit": "2d19cab2b525f885ee8d7efec96093431f6b5f20"
+       }
     ],
     "platforms": [
       "Darwin"


### PR DESCRIPTION
### Pull Request Description

Hello, this pull request adds compatibility check for GRDB with Swift 5.0, 5.1, 5.3, and 5.7.

Compatibility with Swift 5.3 had been added by #574, but it was reverted for some reason (???). This PR restores the deleted compatibility checks.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [X] be an *Xcode* or *swift package manager* project
- [X] support building on either Linux or macOS
- [X] target Linux, macOS, or iOS/tvOS/watchOS device
- [X] be contained in a publicly accessible git repository
- [X] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [X] have maintainers who will commit to resolve issues in a timely manner
- [X] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [X] add value not already included in the suite
- [X] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

```
$ ./project_precommit_check GRDB.swift --earliest-compatible-swift-version 5.7
** CHECK **
--- Validating GRDB.swift Swift version 5.7 compatibility ---
--- Project configured to be compatible with Swift 5.7 ---
--- Checking GRDB.swift platform compatibility with Darwin ---
--- Platform compatibility check succeeded ---
--- Locating swiftc executable ---
$ xcrun -f swiftc
--- Checking installed Swift version ---
$ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --version
swift-driver version: 1.62.15 --- Version check failed ---
Expected version:
Apple Swift version 5.7.0 (swiftlang-5.7.0.123.8 clang-1400.0.29.50)
Target: x86_64-apple-darwin22.3.0

Current version:
Apple Swift version 5.7.2 (swiftlang-5.7.2.135.5 clang-1400.0.29.51)
Target: arm64-apple-macosx13.0

warning: Unexpected swiftc version. Expected swiftc for Swift 5.7 can be found in Xcode 14.0 (contains Swift 5.7.0).
warning: Continuing to build with unexpected swiftc version.

--- Executing build actions ---
$ /Users/groue/Documents/git/groue/swift-source-compat-suite/runner.py --swift-branch swift-5.7-branch --swiftc /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc --projects /Users/groue/Documents/git/groue/swift-source-compat-suite/projects.json --include-repos 'path == "GRDB.swift"' --include-versions 'version == "5.7"' --include-actions 'action.startswith("Build")'
Building 1 projects across 10 parallel processes

PASS: GRDB.swift, 5.7, 2d19ca, Swift Package
========================================
Action Summary:
     Passed: 1
     Failed: 0
    XFailed: 0
    UPassed: 0
      Total: 1
========================================
Repository Summary:
      Total: 1
========================================
Result: PASS
========================================
--- GRDB.swift checked successfully against Swift 5.7 ---
```
