### PR TITLE
Add Swift Power Assert project

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2910,7 +2910,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "4a93a3f5298adf62e593cdc8b86d48da0420ddf4"
+        "commit": "a60cb50b141d723ec51c1788fe454e93d468d5de"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -2910,7 +2910,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "6f9dfba9e571f50057c40f9ea0e9281f2258900d"
+        "commit": "4a93a3f5298adf62e593cdc8b86d48da0420ddf4"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -2903,6 +2903,31 @@
   },
   {
     "repository": "Git",
+    "url": "https://github.com/kishikawakatsumi/swift-power-assert",
+    "path": "swift-power-assert",
+    "branch": "main",
+    "maintainer": "kishikawakatsumi@mac.com",
+    "compatibility": [
+      {
+        "version": "5.0",
+        "commit": "6f9dfba9e571f50057c40f9ea0e9281f2258900d"
+      }
+    ],
+    "platforms": [
+      "Darwin"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      },
+      {
+        "action": "TestSwiftPackage"
+      }
+    ]
+  },
+  {
+    "repository": "Git",
     "url": "https://github.com/apple/swift-standard-library-preview.git",
     "path": "swift-standard-library-preview",
     "branch": "main",


### PR DESCRIPTION
### Pull Request Description

Add [Swift Power Assert](https://github.com/kishikawakatsumi/swift-power-assert) project.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
