### PR TITLE
Re-disable swift-distributed-actors

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3292,7 +3292,15 @@
         "action": "BuildSwiftPackage",
         "build_tests": "true",
         "configuration": "debug",
-        "tags": "sourcekit-disabled swiftpm"
+        "tags": "sourcekit-disabled swiftpm",
+        "xfail": [
+          {
+            "issue": "https://github.com/apple/swift/issues/65011",
+            "compatibility": ["5.7"],
+            "branch": ["main"],
+            "platform": "Darwin"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
This test is still failing in CI when testing PRs. 
See https://github.com/apple/swift/issues/65011

https://ci.swift.org/job/swift-PR-source-compat-suite-test-macOS/178/
