### PR TITLE
Add ability to build tests with release configs

### DIFF
--- a/project.py
+++ b/project.py
@@ -308,7 +308,7 @@ def build_swift_package(path, swiftc, swift_version, configuration,
                              'swift-3.1-branch']):
         command.insert(2, '--disable-sandbox')
 
-    if build_tests and configuration == 'debug':
+    if build_tests:
         command += ['--build-tests']
 
         if sys.platform == "linux":
@@ -411,6 +411,10 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
     if action['action'] == 'BuildSwiftPackage':
         if not build_config:
             build_config = action['configuration']
+
+        build_tests = (action.get('build_tests') == 'true' and build_config == 'debug') \
+                      or (action.get('build_tests_release') and build_config == 'release')
+
         return build_swift_package(os.path.join(root_path, repo['path']),
                                    swiftc, swift_version,
                                    build_config,
@@ -419,7 +423,7 @@ def dispatch(root_path, repo, action, swiftc, swift_version,
                                    added_swift_flags=added_swift_flags,
                                    incremental=incremental,
                                    override_swift_exec=override_swift_exec,
-                                   build_tests=action.get('build_tests') == 'true')
+                                   build_tests=build_tests)
     elif action['action'] == 'TestSwiftPackage':
         return test_swift_package(os.path.join(root_path, repo['path']),
                                   swiftc,

--- a/projects.json
+++ b/projects.json
@@ -3285,16 +3285,9 @@
       {
         "action": "BuildSwiftPackage",
         "build_tests": "true",
+        "build_tests_release": "true",
         "configuration": "debug",
-        "tags": "sourcekit-disabled swiftpm",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/65011",
-            "compatibility": ["5.7"],
-            "branch": ["main"],
-            "platform": "Darwin"
-          }
-        ]
+        "tags": "sourcekit-disabled swiftpm"
       }
     ]
   },


### PR DESCRIPTION
# In This PR
* Add ability to build release configuration of a swift package with `--build-tests` by adding `build_tests_release` to the project configuration

There are projects which are edge cases which need to be able to build even the release configurations of their swift package with `--build-tests` in order to build correctly.  swift-distributed-actors is such a project. By default we only build tests with the debug config of a project, but this gives project owners the ability to override that and force test builds with release config
