### PR TITLE
Disable integrated driver for SourceKit stress tester

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -290,6 +290,7 @@ class StressTesterRunner(object):
             'SK_STRESS_ACTIVE_CONFIG': self.swift_branch,
             'SK_STRESS_REWRITE_MODES': 'none concurrent insideout',
             'SK_STRESS_REQUEST_DURATIONS_FILE': request_durations,
+            'EnableSwiftBuildSystemIntegration': 'NO'
         }
         run_env.update(os.environ)
         run_cmd = ['./runner.py',


### PR DESCRIPTION
`sk-swiftc-wrapper` wraps `swiftc` but if we enable the integrated driver, `swiftc` is not getting called, so there’s nothing to wrap. Until we update the stress tester to wrap `swift-frontend`, disable the integrated driver.
