### PR TITLE
Use a preset for the build-script invocation used by `run_sk_stress_test`

### DIFF
--- a/run_sk_stress_test
+++ b/run_sk_stress_test
@@ -195,49 +195,28 @@ def execute_runner(workspace: str, args: argparse.Namespace) -> bool:
     return passed
 
 
+def get_preset_name(args):
+    build_type = ''
+    if args.debug:
+        build_type = build_type + 'D'
+    else:
+        build_type = build_type + 'R'
+
+    if args.assertions:
+        build_type = build_type + 'A'
+
+    return f'sourcekit_stress_test_macos_{build_type}'
+
 def build_swift_toolchain(workspace: str, args: argparse.Namespace) -> None:
     build_command = [
         os.path.join(workspace, 'swift/utils/build-script'),
-        '--debug' if args.debug else '--release',
-        '--assertions' if args.assertions else '--no-assertions',
-        '--build-ninja',
-        '--llbuild',
-        '--swiftpm',
-        '--swiftsyntax',
-        '--skstresstester',
-        '--ios',
-        '--tvos',
-        '--watchos',
-        '--skip-build-benchmarks',
-        '--build-subdir=compat_macos',
-        '--compiler-vendor=apple',
-        '--',
-        '--darwin-install-extract-symbols',
-        '--darwin-toolchain-alias=swift',
-        '--darwin-toolchain-bundle-identifier=org.swift.compat-macos',
-        '--darwin-toolchain-display-name-short=Swift Development Snapshot',
-        '--darwin-toolchain-display-name=Swift Development Snapshot',
-        '--darwin-toolchain-name=swift-DEVELOPMENT-SNAPSHOT',
-        '--darwin-toolchain-version=3.999.999',
-        '--install-llbuild',
-        '--install-swift',
-        '--install-swiftpm',
-        '--install-swiftsyntax',
-        '--install-skstresstester',
-        '--install-destdir={}/build/compat_macos/install'.format(workspace),
-        '--install-prefix=/toolchain/usr',
-        '--install-symroot={}/build/compat_macos/symroot'.format(workspace),
-        '--installable-package={}/build/compat_macos/root.tar.gz'.format(workspace),
-        '--llvm-install-components=libclang;libclang-headers;dsymutil',
-        '--swift-install-components=compiler;clang-builtin-headers;stdlib;sdk-overlay;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers',
-        '--symbols-package={}/build/compat_macos/root-symbols.tar.gz'.format(workspace),
-        '--verbose-build',
-        '--reconfigure',
+        f'--preset={get_preset_name(args)}',
+        f'install_destdir={workspace}/build/compat_macos/install',
+        f'install_prefix=/toolchain/usr',
+        f'install_symroot={workspace}/build/compat_macos/symroot',
+        f'installable_package={workspace}/build/compat_macos/root.tar.gz',
+        f'symbols_package={workspace}/build/compat_macos/root-symbols.tar.gz',
     ]
-    if args.cmake_c_launcher:
-        build_command += ['--cmake-c-launcher={}'.format(args.cmake_c_launcher)]
-    if args.cmake_cxx_launcher:
-        build_command += ['--cmake-cxx-launcher={}'.format(args.cmake_cxx_launcher)]
     common.check_execute(build_command, timeout=9999999)
 
 


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/65706

---

The hard-coded `build-script` invocation is gross and also didn’t build the new driver, which lead to issues. Use a preset based on the source compat suite presets instead.

Effectively, this will add the following arguments to the `build-script` invocation. `--llvm-install-components` and `--swift-install-components` just show the components the newly added components.

```
--cross-compile-hosts=macosx-arm64
--install-llvm \
--install-swift-driver \
--llvm-install-components=clang;clang-resource-headers;compiler-rt;clang-features-file
--swift-driver \
--swift-install-components=back-deployment;libexec
```