### PR TITLE
[Xfail] swift-power-assert only supports 5.9+

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2920,7 +2920,15 @@
       {
         "action": "BuildSwiftPackage",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke"
+        "tags": "sourcekit sourcekit-smoke",
+        "xfail": [
+            {
+                "issue": "Only Supports 5.9+",
+                "compatibility": "5.0",
+                "branch": ["release/5.8"],
+                "job": ["source-compat"]
+            }
+        ]
       },
       {
         "action": "TestSwiftPackage"


### PR DESCRIPTION
Update xfails to fix 5.8 jobs.

swift-power-assert only supports 5.9+
https://github.com/kishikawakatsumi/swift-power-assert/blob/main/Package.swift#L1
