### PR TITLE
[Stress tester XFails] Update XFails

### DIFF
--- a/sourcekit-xfails.json
+++ b/sourcekit-xfails.json
@@ -1382,7 +1382,7 @@
       "offset" : 4181
     },
     "applicableConfigs" : [
-      "main"
+      "main", "release/5.9"
     ],
     "issueUrl" : "https://github.com/apple/swift/issues/64512"
   },
@@ -1395,7 +1395,7 @@
       "offset" : 4259
     },
     "applicableConfigs" : [
-      "main"
+      "main", "release/5.9"
     ],
     "issueUrl" : "https://github.com/apple/swift/issues/64512"
   },
@@ -1760,7 +1760,7 @@
       "offset" : 1792
     },
     "applicableConfigs" : [
-      "main"
+      "main", "release/5.9"
     ],
     "issueUrl" : "https://github.com/apple/swift/issues/66925"
   },
@@ -1772,7 +1772,7 @@
       "offset" : 4190
     },
     "applicableConfigs" : [
-      "main"
+      "main", "release/5.9"
     ],
     "issueUrl" : "https://github.com/apple/swift/issues/66926"
   }


### PR DESCRIPTION
Mark some XFails on `main` as also XFailed on `release/5.9`
