### PR TITLE
Update SwiftFoundation to include Predicate variadic generics support

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4602,7 +4602,7 @@
     "compatibility": [
       {
         "version": "5.9",
-        "commit": "9e852364819c44cb12e1c1ff26201d96007b4ae7"
+        "commit": "db11c382b354a0a5c0f35a89419394cb9ae233c0"
       }
     ],
     "platforms": [


### PR DESCRIPTION
The current pinned version does not contain `Predicate` variadic generics, which is an area we are seeing a lot of the compact issues. Let's update the version to include that (introduced with https://github.com/apple/swift-foundation/pull/178).

This commit has been tested [here](https://github.com/apple/swift-foundation/pull/199). It passed both macOS and Linux tests.