### PR TITLE
Revert "[Xfail] swift-power-assert for a linking failure"

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2927,12 +2927,6 @@
                 "compatibility": "5.0",
                 "branch": ["release/5.8"],
                 "job": ["source-compat"]
-            },
-            {
-                "issue": "https://github.com/apple/swift/issues/67371",
-                "compatibility": "5.0",
-                "branch": ["main"],
-                "job": ["source-compat"]
             }
         ]
       },


### PR DESCRIPTION
Reverts apple/swift-source-compat-suite#830

Fixed with https://github.com/apple/swift-package-manager/pull/6723 , this will prevent the project UPASSing