### PR TITLE
make build timeout for xcodebuilds match swift packages

### DIFF
--- a/project.py
+++ b/project.py
@@ -246,6 +246,7 @@ class XcodeTarget(ProjectTarget):
         if time_reporter:
             start_time = time.time()
         returncode = common.check_execute(self.get_build_command(incremental=incremental),
+                                          timeout=3600,
                                           sandbox_profile=sandbox_profile,
                                           stdout=stdout, stderr=stdout)
         if returncode == 0 and time_reporter:


### PR DESCRIPTION
### Pull Request Description
* When we build swift packages, our timeout is 3600, we should match that with xcodebuilds. All our spurious timeouts are occurring on xcodebuilds because the previous default timeout isn't enough. Thus we se
`sandbox-exec: Timed out`