### PR TITLE
Fix xcodebuild timeouts in consumer scripts

### DIFF
--- a/common.py
+++ b/common.py
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import shlex
 
-DEFAULT_EXECUTE_TIMEOUT = 10*60
+DEFAULT_EXECUTE_TIMEOUT = 3600
 
 branches = {
     'main': {

--- a/project.py
+++ b/project.py
@@ -246,7 +246,6 @@ class XcodeTarget(ProjectTarget):
         if time_reporter:
             start_time = time.time()
         returncode = common.check_execute(self.get_build_command(incremental=incremental),
-                                          timeout=3600,
                                           sandbox_profile=sandbox_profile,
                                           stdout=stdout, stderr=stdout)
         if returncode == 0 and time_reporter:


### PR DESCRIPTION
## In This PR
* Rather than set the xcodebuild timeout to 3600, set the `DEFAULT_EXECUTE_TIMEOUT` var to 3600, this way consumer scripts can use `common.set_default_execute_timeout()` and override the xcode timeout properly