### PR TITLE
Ensure cperf sets up custom workspaces correctly

### DIFF
--- a/common.py
+++ b/common.py
@@ -41,9 +41,9 @@ def set_default_execute_timeout(timeout):
     DEFAULT_EXECUTE_TIMEOUT = timeout
 
 
-def clone_repos(swift_branch):
+def clone_repos(swift_branch, workspace='.'):
     """Clone Swift and dependencies using update-checkout."""
-    workspace = private_workspace('.')
+    workspace = private_workspace(workspace)
     swift = os.path.join(workspace, "swift")
 
     # Clone swift checkout

--- a/run_cperf
+++ b/run_cperf
@@ -47,7 +47,7 @@ def setup_workspace(instance, workspace, args):
         os.makedirs(workspace)
     swift = os.path.join(workspace, "swift")
     if not os.path.exists(swift):
-        common.clone_repos(swift_branch=args.swift_branch)
+        common.clone_repos(swift_branch=args.swift_branch, workspace=workspace)
     if instance == NEW_INSTANCE:
         command_fetch = ['git', '-C', swift, 'fetch', 'origin',
                          'pull/%d/merge' % args.setup_workspaces_for_pr]


### PR DESCRIPTION
### Pull Request Description
* Fix Workspace bug in performance jobs after move to update_checkout
```
$ git -C /Users/ec2-user/jenkins/workspace-private/swift-PR-compiler-performance-macOS/main/new/swift fetch origin pull/69591/merge
fatal: cannot change to '/Users/ec2-user/jenkins/workspace-private/swift-PR-compiler-performance-macOS/main/new/swift': No such file or directory
WORKSPACE: /Users/ec2-user/jenkins/workspace/swift-PR-compiler-performance-macOS
Traceback (most recent call last):
  File "/Users/ec2-user/jenkins/workspace/swift-PR-compiler-performance-macOS/swift-source-compat-suite/run_cperf", line 632, in <module>
    sys.exit(main())
  File "/Users/ec2-user/jenkins/workspace/swift-PR-compiler-performance-macOS/swift-source-compat-suite/run_cperf", line 117, in main
    setup_workspace(instance, workspace, args)
  File "/Users/ec2-user/jenkins/workspace/swift-PR-compiler-performance-macOS/swift-source-compat-suite/run_cperf", line 54, in setup_workspace
    common.check_execute(command_fetch)
  File "/Users/ec2-user/jenkins/workspace/swift-PR-compiler-performance-macOS/swift-source-compat-suite/common.py", line 220, in check_execute
    raise ExecuteCommandFailure(command, returncode)
common.ExecuteCommandFailure: ExecuteCommandFailure(command="git -C /Users/ec2-user/jenkins/workspace-private/swift-PR-compiler-performance-macOS/main/new/swift fetch origin pull/69591/merge", returncode=128)
```
