### PR TITLE
Add Swift SDK Generator

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -114,6 +114,13 @@ supported_configs = {
                        'Target: x86_64-apple-darwin22.3.0\n',
             'description': 'Xcode 14.0 (contains Swift 5.7.0)',
             'branch': 'swift-5.7-branch'
+        },
+        '5.9': {
+            'version': 'Apple Swift version 5.9 '
+                       '(swiftlang-5.9.0.128.108 clang-1500.0.40.1)\n'
+                       'Target: x86_64-apple-macosx14.0\n',
+            'description': 'Xcode 15.0 (contains Swift 5.9.0)',
+            'branch': 'swift-5.9-branch'
         }
     },
     # NOTE: Linux isn't fully supported yet

--- a/projects.json
+++ b/projects.json
@@ -4771,7 +4771,7 @@
     "compatibility": [
       {
         "version": "5.9",
-        "commit": "bc3a5584fbf645269f2ecf7dd52e69d0e2cecfa3"
+        "commit": "e40e1fb685f834440a7513d9be35b1d3f4820665"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -4762,5 +4762,27 @@
         ]
       }
     ]
+  },{
+    "repository": "Git",
+    "url": "https://github.com/apple/swift-sdk-generator.git",
+    "path": "swift-sdk-generator",
+    "branch": "main",
+    "maintainer": "m_desiatov@apple.com",
+    "compatibility": [
+      {
+        "version": "5.9",
+        "commit": "bc3a5584fbf645269f2ecf7dd52e69d0e2cecfa3"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "configuration": "release"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

We should add https://github.com/apple/swift-sdk-generator to detect regressions.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *SwiftPM*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

The project passes all checks except Swift 4.0 support, since its minimum supported version is 5.9.