### PR TITLE
Remove resolved xfails for swift-testing

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4720,7 +4720,7 @@
     "compatibility": [
       {
         "version": "5.9",
-        "commit": "f9deef4f09f85064a542335b00f35430e8bf7432"
+        "commit": "c6340bd1d0fd486e9b917db086c9a3ffdca2dcaf"
       }
     ],
     "platforms": [
@@ -4735,25 +4735,6 @@
         "build_tests_release": "true",
         "tags": "swiftpm",
         "xfail": [
-          {
-            "issue": "https://github.com/apple/swift/issues/69096",
-            "compatibility": ["5.9"],
-            "branch": ["main"],
-            "job": ["source-compat"]
-          },
-          {
-            "issue": "https://github.com/apple/swift/issues/69278",
-            "compatibility": ["5.9"],
-            "branch": ["release/5.10", "release/5.9"],
-            "job": ["source-compat"]
-          },
-          {
-            "issue": "https://github.com/apple/swift/issues/69279",
-            "compatibility": ["5.9"],
-            "platform": "Linux",
-            "branch": ["main", "release/5.10", "release/5.9"],
-            "job": ["source-compat"]
-          },
           {
             "issue": "Only Supports 5.9+",
             "compatibility": ["5.9"],

--- a/projects.json
+++ b/projects.json
@@ -4719,7 +4719,7 @@
     "maintainer": "bcroom@apple.com",
     "compatibility": [
       {
-        "version": "5.9",
+        "version": "5.10",
         "commit": "c6340bd1d0fd486e9b917db086c9a3ffdca2dcaf"
       }
     ],
@@ -4736,9 +4736,9 @@
         "tags": "swiftpm",
         "xfail": [
           {
-            "issue": "Only Supports 5.9+",
-            "compatibility": ["5.9"],
-            "branch": ["release/5.8"],
+            "issue": "Only Supports 5.10+",
+            "compatibility": ["5.10"],
+            "branch": ["release/5.8", "release/5.9"],
             "job": ["source-compat"]
           }
         ]


### PR DESCRIPTION
### Pull Request Description

Resolve 3 xfails for swift-testing which have now been resolved:

- apple/swift#69096
- apple/swift-testing#138
- apple/swift-testing#139

For context, these xfails were added in these two PRs:

- #851
- #857

I also updated the baseline commit of swift-testing since we landed a [workaround](https://github.com/apple/swift-testing/pull/125) for another Swift compiler issue.

Resolves rdar://116924612