### PR TITLE
Don’t test the Result project in the SourceKit stress tester

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2450,7 +2450,7 @@
         "action": "BuildSwiftPackage",
         "build_tests": "true",
         "configuration": "release",
-        "tags": "sourcekit sourcekit-smoke swiftpm",
+        "tags": "swiftpm",
         "xfail": [
           {
             "issue": "https://github.com/apple/swift/issues/70970",


### PR DESCRIPTION
Result is currently XFailed in the source compat suite. Since the SourceKit stress tester doesn’t respect these XFails, remove it from the stress tester projects for now.
