### PR TITLE
Add Swift 5.10 penny-bot support

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4736,11 +4736,11 @@
     "compatibility": [
       {
         "version": "5.9",
-        "commit": "62006b34c8ac82a91c8e5adbdd7dab6f67c33fbd"
+        "commit": "8668ad450553143fa9f454831dc347542d09cdc4"
       },
       {
         "version": "5.10",
-        "commit": "1a5bdbc2496254aa43a360edf077dcbfb8d4f32b"
+        "commit": "e50c96d4db135f8c49bfc515ccfd8eecbdc59fa9"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -4740,7 +4740,7 @@
       },
       {
         "version": "5.10",
-        "commit": "e50c96d4db135f8c49bfc515ccfd8eecbdc59fa9"
+        "commit": "d879a4bb69581a0b68521f08da6fa656537856be"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -4737,6 +4737,10 @@
       {
         "version": "5.9",
         "commit": "62006b34c8ac82a91c8e5adbdd7dab6f67c33fbd"
+      },
+      {
+        "version": "5.10",
+        "commit": "1a5bdbc2496254aa43a360edf077dcbfb8d4f32b"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

We just enabled the remaining of upcoming feature flags in Penny and updated it to require Swift 5.10, so I thought it's worth updating the source-compat-suite since i've noticed Penny has caught 2-3 compatibility problems so far ever since it was added.

Also while I'm at it, update 5.9 version's SHA to the last commit which supported 5.9.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [x] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
