### PR TITLE
Un-XFAIL RxReactiveObjC in 6.0 configuration

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2507,7 +2507,7 @@
           {
             "issue": "https://github.com/apple/swift/issues/57554",
             "compatibility": ["4.2", "5.0"],
-            "branch": ["release/5.5", "release/5.6", "release/5.7", "release/5.8", "release/5.9", "release/5.10", "release/6.0"],
+            "branch": ["release/5.5", "release/5.6", "release/5.7", "release/5.8", "release/5.9", "release/5.10"],
             "job": ["source-compat"]
           }
         ],


### PR DESCRIPTION
I recently landed a change to suppress warnings for remote clang targets in SwiftPM (https://github.com/apple/swift-package-manager/commit/7ba0eb629490a6db480ccb4da9468dc9db4e0187).