### PR TITLE
Fix CI failures (swift-sdk-generator, penny-bot, swift-distributed-tracing)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4770,7 +4770,10 @@
             "compatibility": ["5.9"],
             "branch": ["release/5.9"],
             "job": ["source-compat"],
-            "platform": "Darwin"
+            "platforms": [
+              "Darwin",
+              "Linux"
+            ],
           }
         ]
       },

--- a/projects.json
+++ b/projects.json
@@ -4773,7 +4773,7 @@
             "platforms": [
               "Darwin",
               "Linux"
-            ],
+            ]
           }
         ]
       },

--- a/projects.json
+++ b/projects.json
@@ -3721,7 +3721,7 @@
     "compatibility": [
       {
         "version": "5.0",
-        "commit": "7a89c904d80fd2dc7c6071806f38d5d0b2d5a1b5"
+        "commit": "4733b6ead3b2d3a3b9b63256a9ba5b567687e7f1"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -4763,7 +4763,16 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "swiftpm"
+        "tags": "swiftpm",
+        "xfail": [
+          {
+            "issue": "https://github.com/apple/swift-package-manager/issues/7521",
+            "compatibility": ["5.9"],
+            "branch": ["release/5.9"],
+            "job": ["source-compat"],
+            "platform": "Darwin"
+          }
+        ]
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -4768,7 +4768,7 @@
           {
             "issue": "https://github.com/apple/swift-package-manager/issues/7521",
             "compatibility": ["5.9"],
-            "branch": ["release/5.9"],
+            "branch": ["main", "release/6.0"],
             "job": ["source-compat"],
             "platforms": [
               "Darwin",

--- a/projects.json
+++ b/projects.json
@@ -4750,8 +4750,8 @@
     "maintainer": "contact@mahdibm.com",
     "compatibility": [
       {
-        "version": "5.9",
-        "commit": "62006b34c8ac82a91c8e5adbdd7dab6f67c33fbd"
+        "version": "5.10",
+        "commit": "b30d76e2dcab8a44aa1f25305266d564aa7c6b41"
       }
     ],
     "platforms": [
@@ -4763,19 +4763,7 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "swiftpm",
-        "xfail": [
-          {
-            "issue": "https://github.com/apple/swift-package-manager/issues/7521",
-            "compatibility": ["5.9"],
-            "branch": ["main", "release/6.0"],
-            "job": ["source-compat"],
-            "platforms": [
-              "Darwin",
-              "Linux"
-            ]
-          }
-        ]
+        "tags": "swiftpm"
       },
       {
         "action": "TestSwiftPackage"

--- a/projects.json
+++ b/projects.json
@@ -4778,7 +4778,7 @@
     "compatibility": [
       {
         "version": "5.9",
-        "commit": "e40e1fb685f834440a7513d9be35b1d3f4820665"
+        "commit": "db85e25d97d0443560cfcff848d20f7690868454"
       }
     ],
     "platforms": [


### PR DESCRIPTION
### Pull Request Description

This fixes swift-sdk-generator compat suite failures.

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.
