### PR TITLE
Temporarily disable penny-bot while we investigate the failure

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -4763,10 +4763,24 @@
         "action": "BuildSwiftPackage",
         "configuration": "release",
         "build_tests": "true",
-        "tags": "swiftpm"
+        "tags": "swiftpm",
+        "xfail": [
+          {
+            "issue": "rdar://128175704",
+            "branch": ["main"],
+            "job": ["source-compat"]
+          }
+        ]
       },
       {
-        "action": "TestSwiftPackage"
+        "action": "TestSwiftPackage",
+        "xfail": [
+          {
+            "issue": "rdar://128175704",
+            "branch": ["main"],
+            "job": ["source-compat"]
+          }
+        ]
       }
     ]
   },{


### PR DESCRIPTION
This is currently failing, presumably due to a package visibility change:
```
swift-source-compat-suite/project_cache/penny-bot/Lambdas/GitHubAPI/GeneratedSources/Types.swift:1147:59: error: initializer 'init(per_page:page:)' is package and cannot be referenced from a default argument value
 1145 |     package func pulls_list_files(
 1146 |         path: Operations.pulls_list_files.Input.Path,
 1147 |         query: Operations.pulls_list_files.Input.Query = .init(),
      |                                                           `- error: initializer 'init(per_page:page:)' is package and cannot be referenced from a default argument value
 1148 |         headers: Operations.pulls_list_files.Input.Headers = .init()
 1149 |     ) async throws -> Operations.pulls_list_files.Output {
      :
30245 |                 ///   - per_page: The number of results per page (max 100).
```

Temporarily disable while we look into it.