### PR TITLE
Add Hummingbird

### DIFF
--- a/project_precommit_check
+++ b/project_precommit_check
@@ -121,6 +121,13 @@ supported_configs = {
                        'Target: x86_64-apple-macosx14.0\n',
             'description': 'Xcode 15.0 (contains Swift 5.9.0)',
             'branch': 'swift-5.9-branch'
+        },
+        '5.10': {
+            'version': 'Apple Swift version 5.10 '
+                       '(swiftlang-5.10.0.13 clang-1500.3.9.4)\n'
+                       'Target: x86_64-apple-macosx14.0\n',
+            'description': 'Xcode 15.4 (contains Swift 5.10.0)',
+            'branch': 'swift-5.10-branch'
         }
     },
     # NOTE: Linux isn't fully supported yet

--- a/projects.json
+++ b/projects.json
@@ -4823,8 +4823,8 @@
     "maintainer": "adamfowler71@gmail.com",
     "compatibility": [
       {
-        "version": "6.0",
-        "commit": "66e311074bff4918b1bb2c2be905961f20fbebd0"
+        "version": "5.10",
+        "commit": "61ca04429d4267e7b30423b7199d7285fde7b9c6"
       }
     ],
     "platforms": [

--- a/projects.json
+++ b/projects.json
@@ -4814,5 +4814,30 @@
         ]
       }
     ]
+  },
+  {
+    "repository": "Git",
+    "url": "https://github.com/hummingbird-project/hummingbird",
+    "path": "hummingbird",
+    "branch": "main",
+    "maintainer": "adamfowler71@gmail.com",
+    "compatibility": [
+      {
+        "version": "6.0",
+        "commit": "66e311074bff4918b1bb2c2be905961f20fbebd0"
+      }
+    ],
+    "platforms": [
+      "Darwin",
+      "Linux"
+    ],
+    "actions": [
+      {
+        "action": "BuildSwiftPackage",
+        "build_tests": "true",
+        "configuration": "release",
+        "tags": "swiftpm"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### Pull Request Description

Add Hummingbird server framework to compat list

### Acceptance Criteria

To be accepted into the Swift source compatibility test suite, a project must:

- [x] be an *Xcode* or *swift package manager* project
- [x] support building on either Linux or macOS
- [x] target Linux, macOS, or iOS/tvOS/watchOS device
- [x] be contained in a publicly accessible git repository
- [ ] maintain a project branch that builds against Swift 4.0 and passes any unit tests
- [x] have maintainers who will commit to resolve issues in a timely manner
- [x] be compatible with the latest GM/Beta versions of *Xcode* and *swiftpm*
- [x] add value not already included in the suite
- [x] be licensed with one of the following permissive licenses:
	* BSD
	* MIT
	* Apache License, version 2.0
	* Eclipse Public License
	* Mozilla Public License (MPL) 1.1
	* MPL 2.0
	* CDDL
- [x] pass `./project_precommit_check` script run

Ensure project meets all listed requirements before submitting a pull request.

The project passes all checks except Swift 4.0 support, since its minimum supported version is 5.9.