### PR TITLE
Update XFAIL for swift-distributed-actors

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -3385,14 +3385,7 @@
         "action": "BuildSwiftPackage",
         "build_tests": "true",
         "build_tests_release": "true",
-        "configuration": "debug",
-        "xfail": [
-          {
-            "issue": "rdar://127206143",
-            "compatibility": ["5.7"],
-            "branch": ["main", "release/6.0"]
-          }
-        ]
+        "configuration": "debug"
       }
     ]
   },


### PR DESCRIPTION
rdar://127206143 is now resolved, but rdar://128941797 is causing the project to still fail. apple/swift#73976 + apple/swift#73997 will resolve this though.